### PR TITLE
Dataset Wrapper

### DIFF
--- a/src/dataset.py
+++ b/src/dataset.py
@@ -1,0 +1,256 @@
+from src.utils import Result, check_file_integrity
+from src.file_extractor import initialize_card_data
+from typing import List, Dict
+from src.constants import (
+    DATA_FIELD_NAME,
+    DATA_FIELD_MANA_COST,
+    DATA_FIELD_TYPES,
+    DATA_SECTION_IMAGES
+)
+
+class Dataset:
+    def __init__(self, retrieve_unknown: bool = False):
+        self._dataset = None
+        self._retrieve_unknown = retrieve_unknown
+        
+    def clear(self) -> None:
+        """
+        Clear the stored dataset
+        """
+        self._dataset = None
+        
+    def open_file(self, file_location: str) -> None:
+        """
+        Open the the dataset file
+        """
+        result = Result.ERROR_MISSING_FILE
+        
+        if not file_location:
+            return result
+            
+        result, json_data = check_file_integrity(file_location)
+        
+        if result != Result.VALID:
+            return result
+            
+        self._dataset = json_data
+        
+        return result
+
+    def get_data_by_id(self, id_list: List[str]) -> List[Dict]:
+        """
+        Takes a list of Arena IDs and returns the corresponding card data for each recognized ID in the dataset.
+        
+        Input Example:
+            id_list: ["90662", "90663"] or [90662, 90663]
+            
+        Output Example:
+            card_data: [
+                {
+                    "name": "Collector's Cage", 
+                    "cmc": 2,
+                    "mana_cost": "{1}{W}",
+                    "isprimarycard": 1,
+                    "linkedfacetype": 0,
+                    "types": ["Artifact"],
+                    "rarity": "mythic", 
+                    "image": ["https://cards.scryfall.io/large/front/a/3/a33703bb-51c0-4d57-9d06-1148507ddc4f.jpg?1712352680"], 
+                    "colors": ["W"], 
+                    "deck_colors": {
+                        "All Decks" : {"gihwr": 62.62, "ohwr": 61.41, ....}
+                        "W": {"gihwr": 0.0, "ohwr": 0.0, ....}
+                        ...
+                    }
+                },
+                {
+                    "name": "Grand Abolisher", 
+                    "cmc": 2,
+                    "mana_cost": "{W}{W}",
+                    "isprimarycard": 1,
+                    "linkedfacetype": 0,
+                    "types": ["Creature"],
+                    "rarity": "mythic", 
+                    "image": ["https://cards.scryfall.io/large/front/e/e/ee793ed2-7d59-4640-8868-ad486600df2c.jpg?1712352691"], 
+                    "colors": ["W"], 
+                    "deck_colors": {
+                        "All Decks" : {"gihwr": 50.85, "ohwr": 50.98, ....}
+                        "W": {"gihwr": 0.0, "ohwr": 0.0, ....}
+                        ...
+                    }
+                }
+            ]
+        """
+        if not isinstance(id_list, list):
+            raise ValueError("Input argument must be a list")
+        
+        card_data = []
+        
+        for arena_id in id_list:
+            string_id = str(arena_id)
+            if self._dataset and string_id in self._dataset["card_ratings"]:
+                card_data.append(self._dataset["card_ratings"][string_id])
+            elif self._retrieve_unknown:
+                empty_dict = {
+                    DATA_FIELD_NAME: string_id,
+                    DATA_FIELD_MANA_COST: "",
+                    DATA_FIELD_TYPES: [],
+                    DATA_SECTION_IMAGES: []
+                }
+                initialize_card_data(empty_dict)
+                card_data.append(empty_dict)
+        
+        return card_data
+        
+    def get_data_by_name(self, name_list: List[str]) -> List[Dict]:
+        """
+        Takes a list of card names and returns the corresponding card data for each recognized name in the dataset.
+        
+        Input Example:
+            name_list: ["Collector's Cage", "Grand Abolisher"]
+            
+        Output Example:
+            card_data: [
+                {
+                    "name": "Collector's Cage", 
+                    "cmc": 2,
+                    "mana_cost": "{1}{W}",
+                    "isprimarycard": 1,
+                    "linkedfacetype": 0,
+                    "types": ["Artifact"],
+                    "rarity": "mythic", 
+                    "image": ["https://cards.scryfall.io/large/front/a/3/a33703bb-51c0-4d57-9d06-1148507ddc4f.jpg?1712352680"], 
+                    "colors": ["W"], 
+                    "deck_colors": {
+                        "All Decks" : {"gihwr": 62.62, "ohwr": 61.41, ....}
+                        "W": {"gihwr": 0.0, "ohwr": 0.0, ....}
+                        ...
+                    }
+                },
+                {
+                    "name": "Grand Abolisher", 
+                    "cmc": 2,
+                    "mana_cost": "{W}{W}",
+                    "isprimarycard": 1,
+                    "linkedfacetype": 0,
+                    "types": ["Creature"],
+                    "rarity": "mythic", 
+                    "image": ["https://cards.scryfall.io/large/front/e/e/ee793ed2-7d59-4640-8868-ad486600df2c.jpg?1712352691"], 
+                    "colors": ["W"], 
+                    "deck_colors": {
+                        "All Decks" : {"gihwr": 50.85, "ohwr": 50.98, ....}
+                        "W": {"gihwr": 0.0, "ohwr": 0.0, ....}
+                        ...
+                    }
+                }
+            ]
+        """
+        
+        if not isinstance(name_list, list):
+            raise ValueError("Input argument must be a list")
+        
+        card_data = []
+        
+        # Remove the arena ID part of the dictionary and make the card name the key
+        transformed_dataset = {v[DATA_FIELD_NAME]: v for v in self._dataset["card_ratings"].values()}
+                
+        for name in name_list:
+            if self._dataset and name in transformed_dataset:
+                card_data.append(transformed_dataset[name])
+            elif self._retrieve_unknown:
+                empty_dict = {
+                    DATA_FIELD_NAME: name,
+                    DATA_FIELD_MANA_COST: "",
+                    DATA_FIELD_TYPES: [],
+                    DATA_SECTION_IMAGES: []
+                }
+                initialize_card_data(empty_dict)
+                card_data.append(empty_dict)
+                
+        return card_data
+    
+    def get_names_by_id(self, id_list: List[str]) -> List[str]:
+        """
+        Takes a list of Arena IDs and returns the corresponding card name for each recognized ID in the dataset.
+        
+        Input Example:
+            name_list: ["90662", "90663","90670"] or [90662, 90663, 90670]
+            
+        Output Example:
+            id_list: ["Collector's Cage", "Grand Abolisher", "Harvester of Misery"]
+        """
+        if not isinstance(id_list, list):
+            raise ValueError("Input argument must be a list")
+        
+        name_list = []
+        
+        if self._dataset is None:
+            return name_list
+            
+        for arena_id in id_list:
+            string_id = str(arena_id)
+            if string_id in self._dataset["card_ratings"]:
+                name_list.append(self._dataset["card_ratings"][string_id][DATA_FIELD_NAME])
+                
+        return name_list
+        
+    def get_ids_by_name(self, name_list: List[str], return_int: bool = False) -> List[str]:
+        """
+        Takes a list of card names and returns the corresponding Arena ID for each recognized name in the dataset, returned as an integer or string. 
+         If there are multiple entries for a name, the function returns the Arena ID from the last entry.
+        
+        Input Examples:
+            Example 1: 
+                name_list: ["Collector's Cage", "Grand Abolisher", "Harvester of Misery"]
+                return_int: False
+                
+            Example 2: 
+                name_list: ["Collector's Cage", "Grand Abolisher", "Harvester of Misery"]
+                return_int: True
+        Output Examples:
+            Example 1: 
+                id_list: ["90662", "90663","90670"]
+            
+            Example 2: 
+                id_list: [90662, 90663, 90670]
+        """
+        if not isinstance(name_list, list):
+            raise ValueError("name_list argument must be a list")
+            
+        if not isinstance(return_int, bool):
+            raise ValueError("return_int argument must be a bool")
+            
+        id_list = []
+        
+        if self._dataset is None:
+            return id_list
+            
+        # Make the name the key and the id the value
+        transformed_dataset = {v[DATA_FIELD_NAME]: k for k, v in self._dataset["card_ratings"].items()}
+            
+        for name in name_list:
+            if name in transformed_dataset:
+                id_list.append(int(transformed_dataset[name]) if return_int else transformed_dataset[name])
+                
+        return id_list
+        
+    def get_color_ratings(self) -> Dict:
+        """
+        Returns the 'color_ratings' section of the dataset
+        """
+        color_ratings = {}
+        
+        if self._dataset is not None:
+            color_ratings = self._dataset["color_ratings"]
+            
+        return color_ratings
+        
+    def get_card_ratings(self) -> Dict:
+        """
+        Returns the 'card_ratings' section of the dataset
+        """
+        card_ratings = {}
+        
+        if self._dataset is not None:
+            card_ratings = self._dataset["card_ratings"]
+            
+        return card_ratings

--- a/src/overlay.py
+++ b/src/overlay.py
@@ -1002,8 +1002,7 @@ class Overlay(ScaledWindow):
             if self.compare_table is None or self.compare_list is None:
                 return
 
-            card_list = self.draft.set_data["card_ratings"] if self.draft.set_data else [
-            ]
+            card_list = self.draft.set_data.get_card_ratings()
 
             taken_cards = self.draft.retrieve_taken_cards()
 
@@ -1970,10 +1969,9 @@ class Overlay(ScaledWindow):
 
             card_frame = tkinter.Frame(popup)
             set_card_names = []
+            set_data = self.draft.set_data.get_card_ratings()
 
-            if self.draft.set_data:
-                set_data = self.draft.set_data["card_ratings"]
-
+            if set_data:
                 set_card_names = [v[constants.DATA_FIELD_NAME]
                                   for k, v in set_data.items()]
 

--- a/tests/test_card_logic.py
+++ b/tests/test_card_logic.py
@@ -5,6 +5,7 @@ from src import constants
 from src.set_metrics import SetMetrics
 from src.configuration import Configuration, Settings
 from src.card_logic import CardResult
+from src.dataset import Dataset
 
 # 17Lands OTJ data from 2024-4-16 to 2024-5-3
 OTJ_PREMIER_SNAPSHOT = os.path.join(os.getcwd(), "tests", "data","OTJ_PremierDraft_Data_2024_5_3.json")
@@ -78,13 +79,11 @@ def fixture_card_result():
     
 @pytest.fixture(name="otj_premier", scope="module")
 def fixture_otj_premier():
-    with open(OTJ_PREMIER_SNAPSHOT, 'r', encoding="utf-8", errors="replace") as json_file:
-        set_data = json.loads(json_file.read())
-        set_metrics = SetMetrics(set_data, 2)
-        # Remove the arena ID part of the dictionary and make the card name the key
-        transformed_data = {v["name"]: v for v in set_data["card_ratings"].values()}
+    dataset = Dataset()
+    dataset.open_file(OTJ_PREMIER_SNAPSHOT)
+    set_metrics = SetMetrics(dataset, 2)
         
-    return set_metrics, transformed_data
+    return set_metrics, dataset
     
 #The card data is pulled from the JSON set files downloaded from 17Lands, excluding the fake card
 @pytest.mark.parametrize("card_list, expected_tier",TIER_TESTS)
@@ -96,12 +95,13 @@ def test_tier_results(card_result, card_list, expected_tier):
     
 @pytest.mark.parametrize("card_name, colors, field, expected_grade", OTJ_GRADE_TESTS)
 def test_otj_grades(otj_premier, card_name, colors, field, expected_grade):
-    metrics, transformed_data = otj_premier
-    assert card_name in transformed_data
+    metrics, dataset = otj_premier
+    data_list = dataset.get_data_by_name([card_name])
+    assert data_list
     
     config = Configuration(settings=Settings(result_format=constants.RESULT_FORMAT_GRADE))
     results = CardResult(metrics, None, config, 2)
-    card_data = transformed_data[card_name]
+    card_data = data_list[0]
     result_list = results.return_results([card_data], [colors],  {"Column1" : field})
     
     assert result_list[0]["results"][0] == expected_grade

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,82 @@
+import pytest
+import os
+from src.dataset import Dataset
+from src.utils import Result
+
+# 17Lands OTJ data from 2024-4-16 to 2024-5-3
+OTJ_PREMIER_SNAPSHOT = os.path.join(os.getcwd(), "tests", "data","OTJ_PremierDraft_Data_2024_5_3.json")
+
+OTJ_GET_IDS_BY_NAME_TESTS_PASS = [
+    (["Rest in Peace", "Thoughtseize", "Djinn of Fool's Fall", "Slick Sequence"], False, ["87050", "90718", "90389", "90579"]),
+    (["Rest in Peace", "Thoughtseize", "Djinn of Fool's Fall", "Slick Sequence"], True, [87050, 90718, 90389, 90579]),
+    (["Brazen Borrower", "Fake Card", "Mentor of the Meek", "Crime /// Punishment"], False, ["90652", "90737"]),
+    (["Brazen Borrower", "Fake Card", "Mentor of the Meek", "Crime /// Punishment"], True, [90652, 90737]),
+    (["Consign /// Oblivion", "Shock", "Enlisted Wurm"], False, []),
+    (["Consign /// Oblivion", "Shock", "Enlisted Wurm"], True, []),
+    ([], False, []),
+    ([], True, []),
+]
+
+OTJ_GET_NAMES_BY_ID_TESTS_PASS = [
+    (["73807", "73905", "90389", "90579"], ["Rest in Peace", "Thoughtseize", "Djinn of Fool's Fall", "Slick Sequence"]),
+    ([73807, 73905, 90389, 90579], ["Rest in Peace", "Thoughtseize", "Djinn of Fool's Fall", "Slick Sequence"]),
+    (["70186", "90737"], ["Brazen Borrower", "Crime /// Punishment"]),
+    ([70186, 90737], ["Brazen Borrower", "Crime /// Punishment"]),
+    (["73807", "73905", "ABCD", 90579], ["Rest in Peace", "Thoughtseize", "Slick Sequence"]),
+    (["73807", "73905", "", 90579], ["Rest in Peace", "Thoughtseize", "Slick Sequence"]),
+    ([], []),
+]
+
+OTJ_GET_DATA_BY_ID_TEST_PASS = [
+    (["73807"], [{"name": "Rest in Peace", "cmc": 2, "mana_cost": "{1}{W}"}]),
+    ([73807], [{"name": "Rest in Peace", "cmc": 2, "mana_cost": "{1}{W}"}]),
+    ([90389], [{"name": "Djinn of Fool's Fall", "cmc": 5, "mana_cost": "{4}{U}"}]),
+    (["73905", 90389], [{"name": "Thoughtseize", "cmc": 1, "mana_cost": "{B}"},{"name": "Djinn of Fool's Fall", "cmc": 5, "mana_cost": "{4}{U}"}]),
+    ([], []),
+]
+
+OTJ_GET_DATA_BY_NAME_TEST_PASS = [
+    (["Rest in Peace"], [{"name": "Rest in Peace", "cmc": 2, "mana_cost": "{1}{W}"}]),
+    (["Djinn of Fool's Fall"], [{"name": "Djinn of Fool's Fall", "cmc": 5, "mana_cost": "{4}{U}"}]),
+    (["Thoughtseize", "Djinn of Fool's Fall"], [{"name": "Thoughtseize", "cmc": 1, "mana_cost": "{B}"},{"name": "Djinn of Fool's Fall", "cmc": 5, "mana_cost": "{4}{U}"}]),
+    ([], []),
+]
+
+@pytest.fixture(name="otj_dataset", scope="module")
+def fixture_otj_dataset():
+    dataset = Dataset()
+    dataset.open_file(OTJ_PREMIER_SNAPSHOT)
+    return dataset
+    
+@pytest.mark.parametrize("name_list, return_int, expected_ids", OTJ_GET_IDS_BY_NAME_TESTS_PASS)
+def test_otj_get_ids_by_name(otj_dataset, name_list, return_int, expected_ids):
+    assert otj_dataset.get_ids_by_name(name_list, return_int) == expected_ids
+    
+    
+@pytest.mark.parametrize("id_list, expected_names", OTJ_GET_NAMES_BY_ID_TESTS_PASS)
+def test_otj_get_names_by_id(otj_dataset, id_list,  expected_names):
+    assert otj_dataset.get_names_by_id(id_list) == expected_names
+    
+@pytest.mark.parametrize("id_list, expected_data", OTJ_GET_DATA_BY_ID_TEST_PASS)
+def test_otj_get_data_by_id(otj_dataset, id_list, expected_data):
+    data_list = otj_dataset.get_data_by_id(id_list)
+    assert len(data_list) == len(expected_data)
+    
+    for i in range(len(data_list)):
+        # Compare the matching fields, ignoring all of the other fields
+        assert all(data_list[i].get(key) == expected_data[i].get(key) for key in data_list[i].keys() & expected_data[i].keys()), f"Get Data by ID: Collected:{data_list[i]}, Expected:{expected_data[i]}"
+    
+@pytest.mark.parametrize("name_list, expected_data", OTJ_GET_DATA_BY_NAME_TEST_PASS)
+def test_otj_get_data_by_name(otj_dataset, name_list, expected_data):
+    data_list = otj_dataset.get_data_by_name(name_list)
+    assert len(data_list) == len(expected_data)
+    
+    for i in range(len(data_list)):
+        # Compare the matching fields, ignoring all of the other fields
+        assert all(data_list[i].get(key) == expected_data[i].get(key) for key in data_list[i].keys() & expected_data[i].keys()), f"Get Data by Name: Collected:{data_list[i]}, Expected:{expected_data[i]}"
+    
+def test_open_file_fail():
+    dataset = Dataset()
+    assert Result.ERROR_MISSING_FILE == dataset.open_file("fake_location")
+    
+

--- a/tests/test_set_metrics.py
+++ b/tests/test_set_metrics.py
@@ -2,6 +2,7 @@ import pytest
 import os
 import json
 from src.set_metrics import SetMetrics
+from src.dataset import Dataset
 from src.constants import (
     DATA_FIELD_GIHWR,
     DATA_FIELD_OHWR,
@@ -108,19 +109,15 @@ OTJ_PREMIER_EXPECTED_RESULTS = [
 
 @pytest.fixture(name="mkm_premier", scope="module")
 def fixture_mkm_premier():
-    set_data = {}
-    with open(MKM_PREMIER_SNAPSHOT, 'r', encoding="utf-8", errors="replace") as json_file:
-        set_data = json.loads(json_file.read())
-        
-    return SetMetrics(set_data, 1)
+    dataset = Dataset()
+    dataset.open_file(MKM_PREMIER_SNAPSHOT)
+    return SetMetrics(dataset, 1)
     
 @pytest.fixture(name="otj_premier", scope="module")
 def fixture_otj_premier():
-    set_data = {}
-    with open(OTJ_PREMIER_SNAPSHOT, 'r', encoding="utf-8", errors="replace") as json_file:
-        set_data = json.loads(json_file.read())
-        
-    return SetMetrics(set_data, 1)
+    dataset = Dataset()
+    dataset.open_file(OTJ_PREMIER_SNAPSHOT)
+    return SetMetrics(dataset, 1)
     
 @pytest.fixture(name="missing_set", scope="module")
 def fixture_missing_set():


### PR DESCRIPTION
I created the wrapper class for the dataset mentioned during the [OCR discussion](https://github.com/unrealities/MTGA_Draft_17Lands/discussions/9). It has a few methods that should make it easier to integrate your OCR changes with the app.

You can use the get_ids_by_name() method to convert card names from your API to Arena IDs used by the ArenaScanner object. You can handle the API data similarly to pack data read from the log.

Here's an example.

![image](https://github.com/unrealities/MTGA_Draft_17Lands/assets/151777715/40411d5e-8096-45dd-8d6f-2499fbb2d894)



