### PR TITLE
Cleanup

### DIFF
--- a/src/log_scanner.py
+++ b/src/log_scanner.py
@@ -2,7 +2,6 @@
 import os
 import json
 import re
-import requests
 import logging
 import src.constants as constants
 import src.card_logic as CL
@@ -278,21 +277,13 @@ class ArenaScanner:
             if not pack_cards:
                 return
 
-            # Exit if there are already cards for P1P1
-            if self.initial_pack[0]:
-                return
-
-
             # initial_pack: the contents of the pack when it's first seen
             # pack_cards: the current contents of the pack
             # The app is recording both of these to determine which cards didn't wheel.
             self.initial_pack[0] = pack_cards
             self.pack_cards[0] = pack_cards
-
-            # Don't overwrite the pack and pick numbers if you're beyond P1P1
-            if (self.current_pack == 0) and (self.current_pick == 0):
-                self.current_pack = 1
-                self.current_pick = 1
+            self.current_pack = 1
+            self.current_pick = 1
 
         except Exception as error:
             logger.error(error)
@@ -336,7 +327,7 @@ class ArenaScanner:
                             pick = json_find("PickNumber", draft_data)
                             
                             # Exit if you're not receiving P1P1
-                            if pack != 1 and pick != 1:
+                            if pack != 1 or pick != 1:
                                 break
 
                             pack_index = (pick - 1) % 8
@@ -758,7 +749,7 @@ class ArenaScanner:
                             pick = json_find("PickNumber", draft_data)
 
                             # Exit if you're not receiving P1P1
-                            if pack != 1 and pick != 1:
+                            if pack != 1 or pick != 1:
                                 break
 
                             pack_index = (pick - 1) % 8

--- a/tests/test_log_scanner.py
+++ b/tests/test_log_scanner.py
@@ -3,7 +3,7 @@ import os
 from typing import List
 from pydantic.dataclasses import dataclass
 from pydantic import Field
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from src.log_scanner import ArenaScanner, Source
 from src.limited_sets import SetDictionary, SetInfo
 
@@ -15,6 +15,22 @@ OTJ_PREMIER_SNAPSHOT = os.path.join(os.getcwd(), "tests", "data","OTJ_PremierDra
 
 OTJ_EVENT_ENTRY = r'[UnityCrossThreadLogger]==> Event_Join {"id":"11a8f74b-1afb-4d25-bb35-55d43674c808","request":"{\"EventName\":\"PremierDraft_OTJ_20240416\",\"EntryCurrencyType\":\"Gem\",\"EntryCurrencyPaid\":1500,\"CustomTokenId\":null}"}'
 OTJ_P1P1_ENTRY = r'[UnityCrossThreadLogger]==> LogBusinessEvents {"id":"a5515a1a-d96e-4da3-9a4a-c03cc4b2b938","request":"{\"PlayerId\":null,\"ClientPlatform\":null,\"DraftId\":\"87b408d1-43e0-4fb5-8c74-a1227fde087c\",\"EventId\":\"PremierDraft_OTJ_20240416\",\"SeatNumber\":1,\"PackNumber\":1,\"PickNumber\":1,\"PickGrpId\":90459,\"CardsInPack\":[90734,90584,90631,90362,90440,90349,90486,90527,90406,90439,90488,90480,90388,90459],\"AutoPick\":false,\"TimeRemainingOnPick\":63.99701,\"EventType\":24,\"EventTime\":\"2024-05-08T00:56:34.4223433Z\"}"}'
+OTJ_P1P1_CARD_NAMES =[
+    "Back for More",
+    "Wrangler of the Damned",
+    "Holy Cow",
+    "Mourner's Surprise",
+    "Armored Armadillo",
+    "Reckless Lackey",
+    "Snakeskin Veil",
+    "Peerless Ropemaster",
+    "Lively Dirge",
+    "Return the Favor",
+    "Magebane Lizard",
+    "Deepmuck Desperado",
+    "Vadmir, New Blood"
+]
+OTJ_P1P2_ENTRY_SKIP = r'[UnityCrossThreadLogger]==> LogBusinessEvents {"id":"972efef7-cd60-4254-ae18-634210287c95","request":"{\"PlayerId\":null,\"ClientPlatform\":null,\"DraftId\":\"87b408d1-43e0-4fb5-8c74-a1257fde087c\",\"EventId\":\"PremierDraft_OTJ_20240416\",\"SeatNumber\":1,\"PackNumber\":1,\"PickNumber\":2,\"PickGrpId\":90701,\"CardsInPack\":[90702,90417,90607,90524,90481,90588,90440,90418,90353,90494,90360,90609,90548],\"AutoPick\":false,\"TimeRemainingOnPick\":30.8176479,\"EventType\":24,\"EventTime\":\"2024-05-08T00:57:07.6027017Z\"}"}'
 
 TEST_SETS = SetDictionary(data={
     "OTJ" : SetInfo(seventeenlands=["OTJ"]),
@@ -89,6 +105,19 @@ OTJ_PREMIER_DRAFT_ENTRIES_2024_5_7 = [
                  card_pool=["90459"],
                  missing=[]),
     r'[UnityCrossThreadLogger]Draft.Notify {"draftId":"87b408d1-43e0-4fb5-8c74-a1257fde017c","SelfPick":2,"SelfPack":1,"PackCards":"90701,90416,90606,90524,90481,90588,90440,90418,90353,90494,90360,90609,90548"}'
+    ),
+    ("P1P2 - Pack Skip Repeat",
+    EventResults(new_event=False,
+                 data_update=False,
+                 current_set="OTJ",
+                 current_event="PremierDraft",
+                 current_pack=1,
+                 current_pick=2,
+                 picks=[],
+                 pack=["90701","90416","90606","90524","90481","90588","90440","90418","90353","90494","90360","90609","90548"],
+                 card_pool=["90459"],
+                 missing=[]),
+    OTJ_P1P2_ENTRY_SKIP
     ),
     ("P1P9 - Pack",
     EventResults(new_event=False,
@@ -438,7 +467,6 @@ def fixture_otj_scanner():
     if os.path.exists(TEST_LOG_FILE_LOCATION):
         os.remove(TEST_LOG_FILE_LOCATION)
 
-@patch("src.ocr.OCR.get_pack")
 def event_test_cases(test_scanner, event_label, entry_label, expected, entry_string, mock_ocr):
     """Generic test cases for verifying the log events"""
     # Write the entry to the fake Player.log file
@@ -448,162 +476,170 @@ def event_test_cases(test_scanner, event_label, entry_label, expected, entry_str
     # Verify that a new event was detected
     new_event = test_scanner.draft_start_search()
     assert expected.new_event == new_event, f"Test Failed: New Event, Set: {event_label}, {entry_label}, Expected: {expected.new_event}, Actual: {new_event}"
-    
+
     # Verify that new event data was collected
     data_update = test_scanner.draft_data_search(Source.UPDATE)
     assert expected.data_update == data_update, f"Test Failed: Data Update, Set: {event_label}, {entry_label}, Expected: {expected.data_update}, Actual: {data_update}"
-    
+
     # Verify the current set and event
     current_set, current_event = test_scanner.retrieve_current_limited_event()
     assert (expected.current_set, expected.current_event) == (current_set, current_event), f"Test Failed: Set and Event, Set: {event_label}, {entry_label}, Expected: {(expected.current_set, expected.current_event)}, Actual: {(current_set, current_event)}"
-    
+
     # Verify the current pack, pick
     current_pack, current_pick = test_scanner.retrieve_current_pack_and_pick()
     assert (expected.current_pack, expected.current_pick) == (current_pack, current_pick), f"Test Failed: Pack/Pick, Set: {event_label}, {entry_label}, Expected: {(expected.current_pack, expected.current_pick)}, Actual: {(current_pack, current_pick)}"
-    
+
     # Verify the pack cards
     pack = [x["name"] for x in test_scanner.retrieve_current_pack_cards()]
     assert expected.pack == pack, f"Test Failed: Pack Cards, Set: {event_label}, {entry_label}, Expected: {expected.pack}, Actual: {pack}"
-    
+
     # Verify the card pool
     card_pool = [x["name"] for x in test_scanner.retrieve_taken_cards()]
     assert expected.card_pool == card_pool, f"Test Failed: Card Pool, Set: {event_label}, {entry_label}, Expected: {expected.card_pool}, Actual: {card_pool}"
-    
+
     # Verify the missing cards
     missing = [x["name"] for x in test_scanner.retrieve_current_missing_cards()]
     assert expected.missing == missing, f"Test Failed: Missing, Set: {event_label}, {entry_label}, Expected: {expected.missing}, Actual: {missing}"
-    
+
     # Verify picks
     picks = [x["name"] for x in test_scanner.retrieve_current_picked_cards()]
     assert expected.picks == picks, f"Test Failed: Picks, Set: {event_label}, {entry_label}, Expected: {expected.picks}, Actual: {picks}"
-    
+
     # Verify that the OCR method wasn't called
-    assert mock_ocr.call_count == 0, f"Test Failed: Picks, Set: {event_label}, {entry_label}, OCR Method Called"
+    assert mock_ocr.call_count == 0, f"Test Failed: OCR Check, Set: {event_label}, {entry_label}, Expected: 0, Actual: {mock_ocr.call_count}"
 
 @pytest.mark.parametrize("entry_label, expected, entry_string", OTJ_PREMIER_DRAFT_ENTRIES_2024_5_7)
 def test_otj_premier_draft_new(test_scanner, entry_label, expected, entry_string):
     """
     Verify that the new premier draft entries can be processed
     """
-    event_test_cases(test_scanner, "New OTJ PremierDraft", entry_label, expected, entry_string)
+    with (
+        patch("src.log_scanner.OCR.get_pack") as mock_ocr,
+        patch("src.log_scanner.capture_screen_base64str")
+    ):
+        event_test_cases(test_scanner, "New OTJ PremierDraft", entry_label, expected, entry_string, mock_ocr)
 
 @pytest.mark.parametrize("entry_label, expected, entry_string", MKM_PREMIER_DRAFT_ENTRIES)
 def test_mkm_premier_draft_old(test_scanner, entry_label, expected, entry_string):
     """
     Verify that the old premier draft entries can be processed - WOTC might revert the changes
     """
-    event_test_cases(test_scanner, "Old MKM PremierDraft", entry_label, expected, entry_string)
-    
+    with (
+        patch("src.log_scanner.OCR.get_pack") as mock_ocr,
+        patch("src.log_scanner.capture_screen_base64str")
+    ):
+        event_test_cases(test_scanner, "Old MKM PremierDraft", entry_label, expected, entry_string, mock_ocr)
+
 @pytest.mark.parametrize("entry_label, expected, entry_string", DMU_QUICK_DRAFT_ENTRIES_2024_5_7)
 def test_dmu_quick_draft_new(test_scanner, entry_label, expected, entry_string):
     """
     Verify that the old quick draft entries can be processed - WOTC might revert the changes
     """
-    event_test_cases(test_scanner, "New DMU QuickDraft", entry_label, expected, entry_string)    
-    
+    with (
+        patch("src.log_scanner.OCR.get_pack") as mock_ocr,
+        patch("src.log_scanner.capture_screen_base64str")
+    ):
+        event_test_cases(test_scanner, "New DMU QuickDraft", entry_label, expected, entry_string, mock_ocr)
+
 @pytest.mark.parametrize("entry_label, expected, entry_string", OTJ_QUICK_DRAFT_ENTRIES)
 def test_mkm_quick_draft_old(test_scanner, entry_label, expected, entry_string):
     """
     Verify that the old quick draft entries can be processed - WOTC might revert the changes
     """
-    event_test_cases(test_scanner, "Old OTJ QuickDraft", entry_label, expected, entry_string)
+    with (
+        patch("src.log_scanner.OCR.get_pack") as mock_ocr,
+        patch("src.log_scanner.capture_screen_base64str")
+    ):
+        event_test_cases(test_scanner, "Old OTJ QuickDraft", entry_label, expected, entry_string, mock_ocr)
 
 @pytest.mark.parametrize("entry_label, expected, entry_string", OTJ_TRAD_DRAFT_ENTRIES_2024_5_7)
 def test_quick_trad_draft_old(test_scanner, entry_label, expected, entry_string):
     """
     Verify that the old quick draft entries can be processed - WOTC might revert the changes
     """
-    event_test_cases(test_scanner, "New OTJ TradDraft", entry_label, expected, entry_string)
+    with (
+        patch("src.log_scanner.OCR.get_pack") as mock_ocr,
+        patch("src.log_scanner.capture_screen_base64str")
+    ):
+        event_test_cases(test_scanner, "New OTJ TradDraft", entry_label, expected, entry_string, mock_ocr)
 
 # TODO - Traditional Sealed
 
 # TODO - Sealed
 
-@patch("src.ocr.OCR.get_pack")
-def test_otj_premier_p1p1_ocr_overwrite(mock_ocr, otj_scanner):
+@patch("src.log_scanner.OCR.get_pack")
+@patch("src.log_scanner.capture_screen_base64str")
+def test_otj_premier_p1p1_ocr_overwrite(mock_screenshot, mock_ocr, otj_scanner):
     # Write the event entry to the fake Player.log file
     with open(TEST_LOG_FILE_LOCATION, 'a', encoding="utf-8", errors="replace") as log_file:
         log_file.write(f"{OTJ_EVENT_ENTRY}\n")
-        
+
     # Search for the event
-    otj_scanner.draft_start_search()      
-        
+    otj_scanner.draft_start_search()
+
     # Open the dataset
-    otj_scanner.retrieve_set_data(OTJ_PREMIER_SNAPSHOT)    
-        
+    otj_scanner.retrieve_set_data(OTJ_PREMIER_SNAPSHOT)
+
     # Mock the card names returned by the OCR get_pack method
     expected_names = ["Seraphic Steed", "Spinewoods Armadillo", "Sterling Keykeeper"]
     mock_ocr.return_value = expected_names
-    
+    mock_screenshot.return_value = 0
+
     otj_scanner.draft_data_search(Source.REFRESH)
-        
+
     # Verify the current pack, pick
     current_pack, current_pick = otj_scanner.retrieve_current_pack_and_pick()
     assert (1, 1) == (current_pack, current_pick), f"OCT Test Failed: OCR Pack/Pick, Set: OTJ, Expected: {(1,1)}, Actual: {(current_pack, current_pick)}"
-    
+
     # Verify the pack cards
     card_names = [x["name"] for x in otj_scanner.retrieve_current_pack_cards()]
     assert expected_names == card_names, f"OCR Test Failed: OCR Pack Cards, Set: OTJ, Expected: {expected_names}, Actual: {card_names}"
-    
+
     # Write the P1P1 entry to the fake Player.log file
     with open(TEST_LOG_FILE_LOCATION, 'a', encoding="utf-8", errors="replace") as log_file:
         log_file.write(f"{OTJ_P1P1_ENTRY}\n")
-    
-    expected_names = [
-        "Back for More",
-        "Wrangler of the Damned",
-        "Holy Cow",
-        "Mourner's Surprise",
-        "Armored Armadillo",
-        "Reckless Lackey",
-        "Snakeskin Veil",
-        "Peerless Ropemaster",
-        "Lively Dirge",
-        "Return the Favor",
-        "Magebane Lizard",
-        "Deepmuck Desperado",
-        "Vadmir, New Blood"
-    ]
-    
+
     # Update the ArenaScanner results
     otj_scanner.draft_data_search(Source.UPDATE)
-    
+
     # Verify that P1P1 is overwritten when the log entry is received
     card_names = [x["name"] for x in otj_scanner.retrieve_current_pack_cards()]
-    assert expected_names == card_names, f"OCR Test Failed: Log Pack Cards, Set: OTJ, Expected: {expected_names}, Actual: {card_names}"
-    
+    assert OTJ_P1P1_CARD_NAMES == card_names, f"OCR Test Failed: Log Pack Cards, Set: OTJ, Expected: {OTJ_P1P1_CARD_NAMES}, Actual: {card_names}"
+
     # Verify that the OCR method was only called once
     assert mock_ocr.call_count == 1
-    
-@patch("src.ocr.OCR.get_pack")
-def test_otj_premier_p1p1_ocr_multiclick(mock_ocr, otj_scanner):
+
+@patch("src.log_scanner.OCR.get_pack")
+@patch("src.log_scanner.capture_screen_base64str")
+def test_otj_premier_p1p1_ocr_multiclick(mock_screenshot, mock_ocr, otj_scanner):
     # Write the event entry to the fake Player.log file
     with open(TEST_LOG_FILE_LOCATION, 'a', encoding="utf-8", errors="replace") as log_file:
         log_file.write(f"{OTJ_EVENT_ENTRY}\n")
-        
+
     # Search for the event
-    otj_scanner.draft_start_search()      
-        
+    otj_scanner.draft_start_search()
+
     # Open the dataset
-    otj_scanner.retrieve_set_data(OTJ_PREMIER_SNAPSHOT)    
-        
+    otj_scanner.retrieve_set_data(OTJ_PREMIER_SNAPSHOT)
+
     # Mock the card names returned by the OCR get_pack method
     expected_names = ["Seraphic Steed", "Spinewoods Armadillo", "Sterling Keykeeper"]
     mock_ocr.return_value = expected_names
-    
+    mock_screenshot.return_value = 0
+
     otj_scanner.draft_data_search(Source.REFRESH)
-        
+
     # Verify the current pack, pick
     current_pack, current_pick = otj_scanner.retrieve_current_pack_and_pick()
     assert (1, 1) == (current_pack, current_pick), f"OCR Test Failed: OCR Pack/Pick, Set: OTJ, Expected: {(1,1)}, Actual: {(current_pack, current_pick)}"
-    
+
     # Verify the pack cards
     card_names = [x["name"] for x in otj_scanner.retrieve_current_pack_cards()]
     assert expected_names == card_names, f"OCR Test Failed: OCR Pack Cards, Set: OTJ, Expected: {expected_names}, Actual: {card_names}"
-    
+
     # Simulate refresh clicks
     otj_scanner.draft_data_search(Source.REFRESH)
     otj_scanner.draft_data_search(Source.REFRESH)
-    
+
     # Verify that the OCR method was only called once
     assert mock_ocr.call_count == 1


### PR DESCRIPTION
Summary:
- Fixed a logic mistake in the P1P1 function that I had introduced, resulting in the app processing the 'LogBusinessEvents' entries after P1P1. It's unclear if this would have caused problems, but I wanted to fix it because the original code excluded these events after P1P1.
- Added a test case to test_log_scanner to verify the fix.
- Removed some unnecessary steps from the get_ocr_pack method.
- Reworked some of the new test cases in test_log_scanner to make Pylint happier.
- Removed some unused imports from log_scanner and test_log_scanner."