### PR TITLE
set combiner

### DIFF
--- a/combiner/combine_sets.py
+++ b/combiner/combine_sets.py
@@ -1,0 +1,153 @@
+import json
+import time
+import os
+from constants import COUNTS_DICT
+
+
+class SetCombiner:
+    def __init__(self):
+        self.sets = []
+        self.combined = {}
+
+    def load_json(self, file_path):
+        with open(file_path, "r") as file:
+            data = json.load(file)
+            self.sets.append(data)
+
+    def combine_meta(self):
+        meta = {}
+        for set in self.sets:
+            for key, value in set["meta"].items():
+                if key not in meta:
+                    if "_date" in key:
+                        meta[key] = value.split(" ")[0]
+                    else:
+                        meta[key] = value
+                else:
+                    if key == "collection_date":
+                        if time.strptime(
+                            value.split(" ")[0], "%Y-%m-%d"
+                        ) > time.strptime(meta[key], "%Y-%m-%d"):
+                            meta[key] = value
+
+                    elif key == "start_date":
+                        if time.strptime(
+                            value.split(" ")[0], "%Y-%m-%d"
+                        ) < time.strptime(meta[key], "%Y-%m-%d"):
+                            meta[key] = value
+
+                    elif key == "end_date":
+                        if time.strptime(
+                            value.split(" ")[0], "%Y-%m-%d"
+                        ) > time.strptime(meta[key], "%Y-%m-%d"):
+                            meta[key] = value
+
+                    elif key == "version":
+                        if value > meta[key]:
+                            meta[key] = value
+
+                    elif key == "game_count":
+                        meta[key] += value
+        return meta
+
+    def combine_color_ratings(self):
+        color_ratings = {}
+        first = True
+        for set in self.sets:
+            color_ratings_keys = list(color_ratings.keys())
+            count = set["meta"]["game_count"]
+            if not first:
+                for key in color_ratings_keys:
+                    if key not in set["color_ratings"].keys():
+                        color_ratings.pop(key, None)
+            for key, value in set["color_ratings"].items():
+                if key not in color_ratings and first:
+                    color_ratings[key] = (value / 100) * count
+                elif key not in color_ratings and not first:
+                    continue
+                else:
+                    color_ratings[key] += (value / 100) * count
+                    color_ratings[key] /= self.combined["meta"]["game_count"]
+                    color_ratings[key] = round(color_ratings[key] * 100, 1)
+            first = False
+        return color_ratings
+
+    def combine_card_ratings(self):
+        from constants import COUNTS_DICT
+        card_ratings = {}
+        
+        COUNTS_DICT['pool'] = None
+        
+        for set_data in self.sets:
+            for card_id, card_data in set_data["card_ratings"].items():
+                if card_id not in card_ratings:
+                    card_ratings[card_id] = {
+                        "name": card_data["name"],
+                        "cmc": card_data["cmc"],
+                        "mana_cost": card_data["mana_cost"], 
+                        "isprimarycard": card_data["isprimarycard"],
+                        "linkedfacetype": card_data["linkedfacetype"],
+                        "types": card_data["types"].copy(),
+                        "rarity": card_data["rarity"],
+                        "image": card_data["image"].copy(),
+                        "colors": card_data["colors"].copy(),
+                        "deck_colors": {}
+                    }
+                
+                for color, stats in card_data["deck_colors"].items():
+                    if color not in card_ratings[card_id]["deck_colors"]:
+                        card_ratings[card_id]["deck_colors"][color] = {}
+                    
+                    for stat, value in stats.items():
+                        if stat in COUNTS_DICT or stat == 'pool':
+                            current = card_ratings[card_id]["deck_colors"][color].get(stat, 0)
+                            card_ratings[card_id]["deck_colors"][color][stat] = current + value
+                        else:
+                            count_stat = COUNTS_DICT.get(stat)
+                            if count_stat:
+                                current_value = card_ratings[card_id]["deck_colors"][color].get(stat, None)
+                                if current_value == 0.0 or value == 0.0:
+                                    card_ratings[card_id]["deck_colors"][color][stat] = 0.0
+                                else:
+                                    count = stats.get(count_stat, 0)
+                                    current_count = card_ratings[card_id]["deck_colors"][color].get(count_stat, 0)
+                                    total_count = current_count + count
+                                    if total_count > 0:
+                                        weighted_avg = ((current_value * current_count) + (value * count)) / total_count
+                                        card_ratings[card_id]["deck_colors"][color][stat] = round(weighted_avg, 2)
+                                    else:
+                                        card_ratings[card_id]["deck_colors"][color][stat] = round(value, 2)
+                            else:
+                                current_value = card_ratings[card_id]["deck_colors"][color].get(stat, None)
+                                if current_value == 0.0 or value == 0.0:
+                                    card_ratings[card_id]["deck_colors"][color][stat] = 0.0
+                                elif current_value is None:
+                                    card_ratings[card_id]["deck_colors"][color][stat] = round(value, 2)
+                                else:
+                                    card_ratings[card_id]["deck_colors"][color][stat] = round((current_value + value) / 2, 2)
+
+        return card_ratings
+
+
+    def combine_sets(self):
+        try:
+            self.combined["meta"] = self.combine_meta()
+            self.combined["color_ratings"] = self.combine_color_ratings()
+            self.combined["card_ratings"] = self.combine_card_ratings()
+        except Exception as e:
+            print(f"Invalid JSON data: {e}")
+        
+        
+    def get_combined(self, input_file_path):   
+        if "_Top_" in input_file_path:
+            output_file_path = input_file_path.replace("_Top_", "_Combined_")
+        elif "_Middle_" in input_file_path:
+            output_file_path = input_file_path.replace("_Middle_", "_Combined_")
+        elif "_Bottom_" in input_file_path:
+            output_file_path = input_file_path.replace("_Bottom_", "_Combined_")
+        elif "_All_" in input_file_path:
+            output_file_path = input_file_path.replace("_All_", "_Combined_")
+        
+        print("Output file name: " + os.path.abspath(output_file_path))
+        with open(output_file_path, "w") as file:
+            json.dump(self.combined, file, indent=4)

--- a/combiner/combiner_main.py
+++ b/combiner/combiner_main.py
@@ -1,0 +1,35 @@
+import sys
+import os
+from combine_sets import SetCombiner
+
+def check_paths(file_path1, file_path2):
+    file_name1 = os.path.basename(file_path1)
+    file_name2 = os.path.basename(file_path2)
+    
+    file1_parts = file_name1.split("_")
+    file2_parts = file_name2.split("_")
+    
+    if file1_parts[0] != file2_parts[0]:
+        print("Error: Datafiles must be from the same cardset.")
+        sys.exit(1)
+        
+    if file1_parts[1] != file2_parts[1]:
+        print("Error: Datafiles must be from the event type.")
+        sys.exit(1) 
+
+
+def main(file_path1, file_path2):
+    check_paths(file_path1, file_path2)
+    combiner = SetCombiner()
+    combiner.load_json(file_path1)
+    combiner.load_json(file_path2)
+    combiner.combine_sets()
+    combiner.get_combined(file_path1)
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(
+            "Usage: python combine_sets.py <file_path1> <file_path2>"
+        )
+    else:
+        main(sys.argv[1], sys.argv[2])

--- a/combiner/constants.py
+++ b/combiner/constants.py
@@ -18,7 +18,7 @@ CARD_COLORS = [
     CARD_COLOR_SYMBOL_BLACK,
     CARD_COLOR_SYMBOL_BLUE,
     CARD_COLOR_SYMBOL_RED,
-    CARD_COLOR_SYMBOL_GREEN
+    CARD_COLOR_SYMBOL_GREEN,
 ]
 
 CARD_COLOR_LABEL_WHITE = "White"
@@ -55,6 +55,10 @@ DATA_FIELD_17LANDS_GDWR = "drawn_win_rate"
 DATA_FIELD_17LANDS_NGD = "drawn_game_count"
 DATA_FIELD_17LANDS_IMAGE = "url"
 DATA_FIELD_17LANDS_IMAGE_BACK = "url_back"
+# Added counts for seen, picked, pool
+DATA_FIELD_17LANDS_SEEN = "seen_count"
+DATA_FIELD_17LANDS_PICKED = "pick_count"
+DATA_FIELD_17LANDS_POOL = "pool_count"
 
 
 DATA_FIELD_GIHWR = "gihwr"
@@ -71,6 +75,10 @@ DATA_FIELD_NGND = "ngnd"
 DATA_FIELD_GDWR = "gdwr"
 DATA_FIELD_NGD = "ngd"
 DATA_FIELD_WHEEL = "wheel"
+# Added seen, picked, pool
+DATA_FIELD_SEEN = "seen"
+DATA_FIELD_PICKED = "picked"
+DATA_FIELD_POOL = "pool"
 
 DATA_SECTION_IMAGES = "image"
 DATA_SECTION_RATINGS = "ratings"
@@ -85,32 +93,42 @@ DATA_FIELD_DISABLED = "disabled"
 DATA_FIELD_RARITY = "rarity"
 DATA_FIELD_MANA_COST = "mana_cost"
 
-DATA_FIELDS_LIST = [DATA_FIELD_GIHWR,
-                    DATA_FIELD_OHWR,
-                    DATA_FIELD_GPWR,
-                    DATA_FIELD_GNSWR,
-                    DATA_FIELD_ALSA,
-                    DATA_FIELD_ATA,
-                    DATA_FIELD_IWD,
-                    DATA_FIELD_NGP,
-                    DATA_FIELD_NGOH,
-                    DATA_FIELD_GIH,
-                    DATA_FIELD_NGND,
-                    DATA_FIELD_GDWR,
-                    DATA_FIELD_NGD]
+DATA_FIELDS_LIST = [
+    DATA_FIELD_GIHWR,
+    DATA_FIELD_OHWR,
+    DATA_FIELD_GPWR,
+    DATA_FIELD_GNSWR,
+    DATA_FIELD_ALSA,
+    DATA_FIELD_ATA,
+    DATA_FIELD_IWD,
+    DATA_FIELD_NGP,
+    DATA_FIELD_NGOH,
+    DATA_FIELD_GIH,
+    DATA_FIELD_NGND,
+    DATA_FIELD_GDWR,
+    DATA_FIELD_NGD,
+    DATA_FIELD_SEEN,
+    DATA_FIELD_PICKED,
+    DATA_FIELD_POOL,
+]
 
-DATA_SET_FIELDS = [DATA_FIELD_GIHWR,
-                   DATA_FIELD_OHWR,
-                   DATA_FIELD_GPWR,
-                   DATA_FIELD_ALSA,
-                   DATA_FIELD_IWD,
-                   DATA_FIELD_CMC,
-                   DATA_FIELD_COLORS,
-                   DATA_FIELD_NAME,
-                   DATA_FIELD_TYPES,
-                   DATA_FIELD_MANA_COST,
-                   DATA_SECTION_IMAGES,
-                   DATA_FIELD_DECK_COLORS]
+DATA_SET_FIELDS = [
+    DATA_FIELD_GIHWR,
+    DATA_FIELD_OHWR,
+    DATA_FIELD_GPWR,
+    DATA_FIELD_ALSA,
+    DATA_FIELD_IWD,
+    DATA_FIELD_CMC,
+    DATA_FIELD_COLORS,
+    DATA_FIELD_NAME,
+    DATA_FIELD_TYPES,
+    DATA_FIELD_MANA_COST,
+    DATA_SECTION_IMAGES,
+    DATA_FIELD_DECK_COLORS,
+    DATA_FIELD_SEEN,
+    DATA_FIELD_PICKED,
+    DATA_FIELD_POOL,
+]
 
 FILTER_OPTION_ALL_DECKS = "All Decks"
 FILTER_OPTION_AUTO = "Auto"
@@ -131,12 +149,46 @@ FIELD_LABEL_GDWR = "GDWR: Games Drawn Win Rate"
 
 DATA_SET_VERSION_3 = 3.0
 
-WIN_RATE_OPTIONS = [DATA_FIELD_GIHWR, DATA_FIELD_OHWR,
-                    DATA_FIELD_GPWR, DATA_FIELD_GNSWR, DATA_FIELD_GDWR]
-NON_COLORS_OPTIONS = WIN_RATE_OPTIONS + \
-    [DATA_FIELD_IWD, DATA_FIELD_ALSA, DATA_FIELD_ATA]
-DECK_COLORS = [FILTER_OPTION_ALL_DECKS, CARD_COLOR_SYMBOL_WHITE, CARD_COLOR_SYMBOL_BLUE, CARD_COLOR_SYMBOL_BLACK, CARD_COLOR_SYMBOL_RED,
-               CARD_COLOR_SYMBOL_GREEN, "WU", "WB", "WR", "WG", "UB", "UR", "UG", "BR", "BG", "RG", "WUB", "WUR", "WUG", "WBR", "WBG", "WRG", "UBR", "UBG", "URG", "BRG"]
+WIN_RATE_OPTIONS = [
+    DATA_FIELD_GIHWR,
+    DATA_FIELD_OHWR,
+    DATA_FIELD_GPWR,
+    DATA_FIELD_GNSWR,
+    DATA_FIELD_GDWR,
+]
+NON_COLORS_OPTIONS = WIN_RATE_OPTIONS + [
+    DATA_FIELD_IWD,
+    DATA_FIELD_ALSA,
+    DATA_FIELD_ATA,
+]
+DECK_COLORS = [
+    FILTER_OPTION_ALL_DECKS,
+    CARD_COLOR_SYMBOL_WHITE,
+    CARD_COLOR_SYMBOL_BLUE,
+    CARD_COLOR_SYMBOL_BLACK,
+    CARD_COLOR_SYMBOL_RED,
+    CARD_COLOR_SYMBOL_GREEN,
+    "WU",
+    "WB",
+    "WR",
+    "WG",
+    "UB",
+    "UR",
+    "UG",
+    "BR",
+    "BG",
+    "RG",
+    "WUB",
+    "WUR",
+    "WUG",
+    "WBR",
+    "WBG",
+    "WRG",
+    "UBR",
+    "UBG",
+    "URG",
+    "BRG",
+]
 COLUMN_OPTIONS = NON_COLORS_OPTIONS
 DECK_FILTERS = [FILTER_OPTION_AUTO] + DECK_COLORS
 
@@ -162,8 +214,7 @@ DRAFT_DETECTION_CATCH_ALL = ["Draft", "draft"]
 DRAFT_START_STRING_EVENT_JOIN = "[UnityCrossThreadLogger]==> Event_Join "
 DRAFT_START_STRING_BOT_DRAFT = "[UnityCrossThreadLogger]==> BotDraft_DraftStatus "
 
-DRAFT_START_STRINGS = [DRAFT_START_STRING_EVENT_JOIN,
-                       DRAFT_START_STRING_BOT_DRAFT]
+DRAFT_START_STRINGS = [DRAFT_START_STRING_EVENT_JOIN, DRAFT_START_STRING_BOT_DRAFT]
 
 DATA_SOURCES_NONE = {"None": ""}
 
@@ -177,26 +228,63 @@ RESULT_FORMAT_WIN_RATE = "Percentage"
 RESULT_FORMAT_RATING = "Rating"
 RESULT_FORMAT_GRADE = "Grade"
 
-RESULT_FORMAT_LIST = [RESULT_FORMAT_WIN_RATE,
-                      RESULT_FORMAT_RATING, RESULT_FORMAT_GRADE]
+RESULT_FORMAT_LIST = [RESULT_FORMAT_WIN_RATE, RESULT_FORMAT_RATING, RESULT_FORMAT_GRADE]
 
 RESULT_UNKNOWN_STRING = " "
 RESULT_UNKNOWN_VALUE = 0.0
 
 LOCAL_DATA_FOLDER_PATH_WINDOWS = os.path.join(
-    "Wizards of the Coast", "MTGA", "MTGA_Data")
+    "Wizards of the Coast", "MTGA", "MTGA_Data"
+)
 LOCAL_DATA_FOLDER_PATH_OSX = os.path.join(
-    "Library", "Application Support", "com.wizards.mtga")
-LOCAL_DATA_FOLDER_PATH_LINUX = next(filter(os.path.exists, [
-    # Steam
-    os.path.join(os.path.expanduser("~"), ".local", "share", "Steam", "steamapps", "common", "MTGA", "MTGA_Data"),
-
-    # Lutris
-    os.path.join(os.path.expanduser("~"), "Games", "magic-the-gathering-arena", "drive_c", "Program Files", "Wizards of the Coast", "MTGA", "MTGA_Data"),
-
-    # Bottles
-    os.path.join(os.path.expanduser("~"), ".var", "app", "com.usebottles.bottles", "data", "bottles", "bottles", "MTG-Arena", "drive_c", "Program Files", "Wizards of the Coast", "MTGA", "MTGA_Data")
-    ]), None)
+    "Library", "Application Support", "com.wizards.mtga"
+)
+LOCAL_DATA_FOLDER_PATH_LINUX = next(
+    filter(
+        os.path.exists,
+        [
+            # Steam
+            os.path.join(
+                os.path.expanduser("~"),
+                ".local",
+                "share",
+                "Steam",
+                "steamapps",
+                "common",
+                "MTGA",
+                "MTGA_Data",
+            ),
+            # Lutris
+            os.path.join(
+                os.path.expanduser("~"),
+                "Games",
+                "magic-the-gathering-arena",
+                "drive_c",
+                "Program Files",
+                "Wizards of the Coast",
+                "MTGA",
+                "MTGA_Data",
+            ),
+            # Bottles
+            os.path.join(
+                os.path.expanduser("~"),
+                ".var",
+                "app",
+                "com.usebottles.bottles",
+                "data",
+                "bottles",
+                "bottles",
+                "MTG-Arena",
+                "drive_c",
+                "Program Files",
+                "Wizards of the Coast",
+                "MTGA",
+                "MTGA_Data",
+            ),
+        ],
+    ),
+    None,
+)
 
 LOCAL_DOWNLOADS_DATA = os.path.join("Downloads", "Raw")
 
@@ -274,10 +362,18 @@ PLATFORM_ID_LINUX = "linux"
 
 LOG_NAME = "Player.log"
 
-LOG_LOCATION_WINDOWS = os.path.join('Users', getpass.getuser(
-), "AppData", "LocalLow", "Wizards Of The Coast", "MTGA", LOG_NAME)
+LOG_LOCATION_WINDOWS = os.path.join(
+    "Users",
+    getpass.getuser(),
+    "AppData",
+    "LocalLow",
+    "Wizards Of The Coast",
+    "MTGA",
+    LOG_NAME,
+)
 LOG_LOCATION_OSX = os.path.join(
-    "Library", "Logs", "Wizards of the Coast", "MTGA", LOG_NAME)
+    "Library", "Logs", "Wizards of the Coast", "MTGA", LOG_NAME
+)
 
 DEFAULT_GIHWR_AVERAGE = 0.0
 
@@ -296,7 +392,8 @@ LIMITED_TYPE_LIST = [
     LIMITED_TYPE_STRING_DRAFT_QUICK,
     LIMITED_TYPE_STRING_DRAFT_TRAD,
     LIMITED_TYPE_STRING_SEALED,
-    LIMITED_TYPE_STRING_TRAD_SEALED]
+    LIMITED_TYPE_STRING_TRAD_SEALED,
+]
 
 LIMITED_USER_GROUP_ALL = "All"
 LIMITED_USER_GROUP_BOTTOM = "Bottom"
@@ -335,8 +432,13 @@ SET_LIST_COUNT_MAX = 50
 
 SET_ARENA_CUBE_START_OFFSET_DAYS = -25
 
-SUPPORTED_SET_TYPES = [SET_TYPE_EXPANSION, SET_TYPE_ALCHEMY,
-                       SET_TYPE_MASTERS, SET_TYPE_CORE, SET_TYPE_DRAFT_INNOVATION]
+SUPPORTED_SET_TYPES = [
+    SET_TYPE_EXPANSION,
+    SET_TYPE_ALCHEMY,
+    SET_TYPE_MASTERS,
+    SET_TYPE_CORE,
+    SET_TYPE_DRAFT_INNOVATION,
+]
 
 TABLE_STYLE = "Treeview"
 
@@ -457,6 +559,16 @@ WIN_RATE_FIELDS_DICT = {
     DATA_FIELD_GDWR: DATA_FIELD_NGD,
 }
 
+COUNTS_DICT = {
+    DATA_FIELD_SEEN: DATA_FIELD_ALSA,
+    DATA_FIELD_PICKED: DATA_FIELD_ATA,
+    DATA_FIELD_NGP: DATA_FIELD_GPWR,
+    DATA_FIELD_NGOH: DATA_FIELD_OHWR,
+    DATA_FIELD_NGD: DATA_FIELD_GDWR,
+    DATA_FIELD_GIH: DATA_FIELD_GIHWR,
+    DATA_FIELD_NGND: DATA_FIELD_GNSWR
+}
+
 DATA_FIELD_17LANDS_DICT = {
     DATA_FIELD_GIHWR: DATA_FIELD_17LANDS_GIHWR,
     DATA_FIELD_OHWR: DATA_FIELD_17LANDS_OHWR,
@@ -471,8 +583,10 @@ DATA_FIELD_17LANDS_DICT = {
     DATA_FIELD_NGND: DATA_FIELD_17LANDS_NGND,
     DATA_FIELD_GDWR: DATA_FIELD_17LANDS_GDWR,
     DATA_FIELD_NGD: DATA_FIELD_17LANDS_NGD,
-    DATA_SECTION_IMAGES: [DATA_FIELD_17LANDS_IMAGE,
-                          DATA_FIELD_17LANDS_IMAGE_BACK]
+    DATA_SECTION_IMAGES: [DATA_FIELD_17LANDS_IMAGE, DATA_FIELD_17LANDS_IMAGE_BACK],
+    DATA_FIELD_SEEN: DATA_FIELD_17LANDS_SEEN,
+    DATA_FIELD_PICKED: DATA_FIELD_17LANDS_PICKED,
+    DATA_FIELD_POOL: DATA_FIELD_17LANDS_POOL,
 }
 
 COLUMNS_OPTIONS_MAIN_DICT = {
@@ -502,14 +616,16 @@ COLUMNS_OPTIONS_EXTRA_DICT = {
     FIELD_LABEL_COLORS: DATA_FIELD_COLORS,
 }
 
-STATS_HEADER_CONFIG = {"Colors": {"width": .19, "anchor": "w"},
-                       "1": {"width": .11, "anchor": "c"},
-                       "2": {"width": .11, "anchor": "c"},
-                       "3": {"width": .11, "anchor": "c"},
-                       "4": {"width": .11, "anchor": "c"},
-                       "5": {"width": .11, "anchor": "c"},
-                       "6+": {"width": .11, "anchor": "c"},
-                       "Total": {"width": .15, "anchor": "c"}}
+STATS_HEADER_CONFIG = {
+    "Colors": {"width": 0.19, "anchor": "w"},
+    "1": {"width": 0.11, "anchor": "c"},
+    "2": {"width": 0.11, "anchor": "c"},
+    "3": {"width": 0.11, "anchor": "c"},
+    "4": {"width": 0.11, "anchor": "c"},
+    "5": {"width": 0.11, "anchor": "c"},
+    "6+": {"width": 0.11, "anchor": "c"},
+    "Total": {"width": 0.15, "anchor": "c"},
+}
 
 ROW_TAGS_BW_DICT = {
     BW_ROW_COLOR_ODD_TAG: (FONT_SANS_SERIF, "#3d3d3d", "#e6ecec"),
@@ -541,7 +657,7 @@ GRADE_ORDER_DICT = {
     LETTER_GRADE_D_MINUS: 3,
     LETTER_GRADE_F: 2,
     LETTER_GRADE_SB: 1,
-    LETTER_GRADE_NA: 0
+    LETTER_GRADE_NA: 0,
 }
 
 TIER_CONVERSION_RATINGS_GRADES_DICT = {
@@ -557,7 +673,7 @@ TIER_CONVERSION_RATINGS_GRADES_DICT = {
     LETTER_GRADE_D_PLUS: 1.5,
     LETTER_GRADE_D: 1.2,
     LETTER_GRADE_D_MINUS: 0.8,
-    LETTER_GRADE_F: 0.4
+    LETTER_GRADE_F: 0.4,
 }
 
 GRADE_DEVIATION_DICT = {
@@ -572,22 +688,42 @@ GRADE_DEVIATION_DICT = {
     LETTER_GRADE_C_MINUS: -0.67,
     LETTER_GRADE_D_PLUS: -1.00,
     LETTER_GRADE_D: -1.33,
-    LETTER_GRADE_D_MINUS: -1.67
+    LETTER_GRADE_D_MINUS: -1.67,
 }
 
 CARD_TYPE_DICT = {
-    CARD_TYPE_SELECTION_ALL: ([CARD_TYPE_CREATURE, CARD_TYPE_PLANESWALKER, CARD_TYPE_INSTANT, CARD_TYPE_SORCERY, CARD_TYPE_ENCHANTMENT, CARD_TYPE_ARTIFACT, CARD_TYPE_LAND], True, False, True),
+    CARD_TYPE_SELECTION_ALL: (
+        [
+            CARD_TYPE_CREATURE,
+            CARD_TYPE_PLANESWALKER,
+            CARD_TYPE_INSTANT,
+            CARD_TYPE_SORCERY,
+            CARD_TYPE_ENCHANTMENT,
+            CARD_TYPE_ARTIFACT,
+            CARD_TYPE_LAND,
+        ],
+        True,
+        False,
+        True,
+    ),
     CARD_TYPE_SELECTION_CREATURES: ([CARD_TYPE_CREATURE], True, False, True),
     CARD_TYPE_SELECTION_NONCREATURES: ([CARD_TYPE_CREATURE], False, False, True),
-    CARD_TYPE_SELECTION_NON_LANDS: ([CARD_TYPE_CREATURE, CARD_TYPE_PLANESWALKER, CARD_TYPE_INSTANT, CARD_TYPE_SORCERY, CARD_TYPE_ENCHANTMENT, CARD_TYPE_ARTIFACT], True, False, True),
+    CARD_TYPE_SELECTION_NON_LANDS: (
+        [
+            CARD_TYPE_CREATURE,
+            CARD_TYPE_PLANESWALKER,
+            CARD_TYPE_INSTANT,
+            CARD_TYPE_SORCERY,
+            CARD_TYPE_ENCHANTMENT,
+            CARD_TYPE_ARTIFACT,
+        ],
+        True,
+        False,
+        True,
+    ),
 }
 
-TABLE_PROPORTIONS = [
-    (1,),
-    (.75, .25),
-    (.60, .20, .20),
-    (.46, .18, .18, .18)
-]
+TABLE_PROPORTIONS = [(1,), (0.75, 0.25), (0.60, 0.20, 0.20), (0.46, 0.18, 0.18, 0.18)]
 
 # TODO: Where are these values from?
 # My understanding is this array is an array for values for each of the first six packs
@@ -632,7 +768,7 @@ UI_SIZE_DICT = {
     "220%": 2.2,
     "230%": 2.3,
     "240%": 2.4,
-    "250%": 2.5
+    "250%": 2.5,
 }
 
 PACK_PARSER_URL = "https://us-central1-mtgalimited.cloudfunctions.net/pack_parser"


### PR DESCRIPTION
Hi, I made this feature to combine two downloaded sets for different user groups (top, middle, bottom) into one set.
I haven't implemented it into the gui yet, because i'm not familiar with tkinter.

For now the program is seperate from the main overlay program.
The current workflow:

1. Download two sets with the gui for the desired user_groups, sets and dates.
2. In the CLI run "python3 ./combiner/combiner_main.py ./Sets/Path_To_Set_1_Middle.json ./Sets/Path_To_Set_2_Top.json"
3. There should now be a new set in the Sets folder called Name_of_Set_1_Combined.json
4. It should now be availabe in the gui.

Let me know what you think of it, it worked fine for me.
One think that I found from the 17lands data that I don't have an explanation for is that the counts for top+middle+bottom events summed up are still smaller that for the 'all' group events. So a lot of statistics for the color individual color pairs are often missing because they don't have enough data.
