### PR TITLE
Fixes and new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Magic: The Gathering Arena draft tool that utilizes 17Lands data.
   - (Linux only) [Install Tk](https://tkdocs.com/tutorial/install.html#installlinux)
 - **Step 7:** In Arena, go to Adjust Options, Account, and then check the Detailed Logs (Plugin Support) check box.
 - **Step 8:** Start the application by opening the terminal and entering ```python main.py```.
-- **Step 9:** If the application asks you for the location of the Arena player log, then click `File->Open` and select the log file from one of the following locations:
+- **Step 9:** If the application asks you for the location of the Arena player log, then click `File->Read Player.log` and select the log file from one of the following locations:
   - **Windows:** {drive}/Users/{username}/AppData/LocalLow/Wizards Of The Coast/MTGA/Player.log
   - **Mac:** {username}/Library/Logs/Wizards Of The Coast/MTGA/Player.log
   - **Bottles (Linux):** /home/{username}/.var/app/com.usebottles.bottles/data/bottles/bottles/MTG-Arena/drive_c/users/{username}/AppData/LocalLow/Wizards Of The Coast/MTGA/Player.log
@@ -130,7 +130,7 @@ Magic: The Gathering Arena draft tool that utilizes 17Lands data.
 ![Settings_Dark](https://github.com/unrealities/MTGA_Draft_17Lands/blob/main/assets/96687942/642a0795-e407-410e-b8d6-6332f3083ac7.png)
 ![Settings_Colors](https://github.com/unrealities/MTGA_Draft_17Lands/blob/main/assets/96687942/90c6b3df-0ade-4f32-a1be-b2ef40cedc32.png)
 
-- **Read Draft Logs:** Read the log file from a draft by selecting `File->Open`. Select a file that has the following naming scheme `DraftLog_<Set>_<Draft Type>_<Draft_ID>.log` file to read the file.
+- **Read Draft Logs:** Read the log file from a draft by selecting `File->Read Draft Log`. Select a file that has the following naming scheme `DraftLog_<Set>_<Draft Type>_<Draft_ID>.log` file to read the file.
 - **Download Set Data:** Open the Download Dataset window by selecting `Data->Download Dataset`. Enter the set information and click the ADD SET button to begin downloading the set data.
   - The download can take several minutes.
   - 17Lands will timeout the request if too many requests are made within a short period.
@@ -261,7 +261,7 @@ The following solution is for P1P1. After you have selected a card, only Arena l
 
 - **Some cards are missing from the Taken Cards window:** Due to Arena creating a new player log after every restart, the application cannot track cards that were picked and seen prior to a restart. However, players in drafting sessions spanning multiple days or sessions can still use this tool to access the current pack data. It should be noted that this application may not have access to information regarding previous packs and picks, resulting in some missing data.
 - **The application can't generate set or debug files:** Windows users might need to run the application as an administrator if the application is installed in a directory with restricted write access.
-- **My sealed card pool is missing after restarting Arena:** Arena creates a new player log after every restart, so you will need to open up your sealed event session log by clicking `File->Open` and selecting the `DraftLog_<Set>_Sealed` file if you want to see your sealed card pool. Remember that opening a log file will prevent the application from reading the Arena player log. Therefore, you must restart the application if you wish to initiate a new Arena event.
+- **My sealed card pool is missing after restarting Arena:** Arena creates a new player log after every restart, so you will need to open up your sealed event session log by clicking `File->Read Draft Log` and selecting the `DraftLog_<Set>_Sealed` file if you want to see your sealed card pool. Remember that opening a log file will prevent the application from reading the Arena player log. Therefore, you must restart the application if you wish to initiate a new Arena event.
 - **The tables are displaying a win rate of 0% or NA:** The application will display a card win rate value of 0% or NA if that win rate field has fewer than 500 samples (e.g., GIHWR will be 0% or NA if the number of games in hand is less than 500). Users should consider using the premier draft dataset or downloading a [tier list](https://github.com/unrealities/MTGA_Draft_17Lands/tree/main/Tools/TierScraper17Lands#tier-list-download-extension) for events that have a low player count.
   - ***As of September 2023, the 17Lands endpoint no longer provides win rate data for cards with fewer than 500 samples.**
 - **CTRL+G doesn't do anything:** If you're a Mac user, this shortcut isn't available. You must run the application as an administrator if you're a Windows user.

--- a/src/constants.py
+++ b/src/constants.py
@@ -15,8 +15,8 @@ CARD_COLOR_SYMBOL_NONE = "NC"
 
 CARD_COLORS = [
     CARD_COLOR_SYMBOL_WHITE,
-    CARD_COLOR_SYMBOL_BLACK,
     CARD_COLOR_SYMBOL_BLUE,
+    CARD_COLOR_SYMBOL_BLACK,
     CARD_COLOR_SYMBOL_RED,
     CARD_COLOR_SYMBOL_GREEN
 ]
@@ -159,11 +159,18 @@ TIER_FILE_PREFIX = "Tier_"
 
 DRAFT_DETECTION_CATCH_ALL = ["Draft", "draft"]
 
-DRAFT_START_STRING_EVENT_JOIN = "[UnityCrossThreadLogger]==> EventJoin "
-DRAFT_START_STRING_BOT_DRAFT = "[UnityCrossThreadLogger]==> BotDraft_DraftStatus "
+DRAFT_START_STRING_PREMIER = "[UnityCrossThreadLogger]==> Event_Join "
+DRAFT_PICK_STRING_PREMIER = "[UnityCrossThreadLogger]==> Event_PlayerDraftMakePick "
+DRAFT_PICK_STRING_PREMIER_OLD = "[UnityCrossThreadLogger]==> Draft.MakeHumanDraftPick "
+DRAFT_P1P1_STRING_PREMIER = "CardsInPack"
+DRAFT_PACK_STRING_PREMIER = "[UnityCrossThreadLogger]Draft.Notify "
 
-DRAFT_START_STRINGS = [DRAFT_START_STRING_EVENT_JOIN,
-                       DRAFT_START_STRING_BOT_DRAFT]
+DRAFT_START_STRING_QUICK_DRAFT = "[UnityCrossThreadLogger]==> BotDraft_DraftStatus "
+DRAFT_PACK_STRING_QUICK = "DraftPack"
+DRAFT_PICK_STRING_QUICK = "[UnityCrossThreadLogger]==> BotDraft_DraftPick "
+
+DRAFT_START_STRINGS = [DRAFT_START_STRING_PREMIER,
+                       DRAFT_START_STRING_QUICK_DRAFT]
 
 DATA_SOURCES_NONE = {"None": ""}
 

--- a/src/log_scanner.py
+++ b/src/log_scanner.py
@@ -17,7 +17,8 @@ from src.utils import (
     json_find,
     Result,
     retrieve_local_set_list,
-    capture_screen_base64str
+    capture_screen_base64str,
+    detect_string,
 )
 
 if not os.path.exists(constants.DRAFT_LOG_FOLDER):
@@ -145,15 +146,13 @@ class ArenaScanner:
                         break
                     offset = log.tell()
                     self.search_offset = offset
-                    for start_string in constants.DRAFT_START_STRINGS:
-                        if start_string in line:
-                            self.draft_start_offset = offset
-                            string_offset = line.find(start_string)
-                            entry_string = line[string_offset + len(start_string):]
-                            event_data = process_json(entry_string)
-                            update, event_type, draft_id = self.__check_event(event_data)
-                            event_line = line
-
+                    start_offset = detect_string(line, constants.DRAFT_START_STRINGS)
+                    if start_offset != -1:
+                        self.draft_start_offset = offset
+                        entry_string = line[start_offset:]
+                        event_data = process_json(entry_string)
+                        update, event_type, draft_id = self.__check_event(event_data)
+                        event_line = line
             if update:
                 self.__new_log(self.draft_sets[0], event_type, draft_id)
                 self.draft_log.info(event_line)
@@ -272,8 +271,8 @@ class ArenaScanner:
             self.__draft_pack_search_premier_v2()
             self.__draft_picked_search_premier_v2()
         elif self.draft_type == constants.LIMITED_TYPE_DRAFT_QUICK:
-            self.__draft_pack_search_quick()
             self.__draft_picked_search_quick()
+            self.__draft_pack_search_quick()
         elif self.draft_type == constants.LIMITED_TYPE_DRAFT_TRADITIONAL:
             # Use OCR to retrieve P1P1
             if use_ocr:
@@ -328,7 +327,6 @@ class ArenaScanner:
         '''Parse premier draft string that contains the P1P1 pack data'''
         offset = self.pack_offset
         draft_data = object()
-        draft_string = "CardsInPack"
         pack_cards = []
         pack = 0
         pick = 0
@@ -343,9 +341,7 @@ class ArenaScanner:
                         break
                     offset = log.tell()
 
-                    string_offset = line.find(draft_string)
-
-                    if string_offset != -1:
+                    if detect_string(line, [constants.DRAFT_P1P1_STRING_PREMIER]) != -1:
                         # Remove any prefix (e.g. log timestamp)
                         start_offset = line.find("{\"id\":")
                         self.draft_log.info(line)
@@ -354,7 +350,7 @@ class ArenaScanner:
 
                         pack_cards = []
                         try:
-                            cards = json_find("CardsInPack", draft_data)
+                            cards = json_find(constants.DRAFT_P1P1_STRING_PREMIER, draft_data)
 
                             for card in cards:
                                 pack_cards.append(str(card))
@@ -395,7 +391,6 @@ class ArenaScanner:
         '''Parse the premier draft string that contains the player pick information'''
         offset = self.pick_offset
         draft_data = object()
-        draft_string = "[UnityCrossThreadLogger]==> EventPlayerDraftMakePick "
         pack = 0
         pick = 0
         # Identify and print out the log lines that contain the draft packs
@@ -408,10 +403,7 @@ class ArenaScanner:
                     if not line:
                         break
                     offset = log.tell()
-
-                    string_offset = line.find(draft_string)
-
-                    if string_offset != -1:
+                    if detect_string(line, [constants.DRAFT_PICK_STRING_PREMIER]) != -1:
                         self.pick_offset = offset
                         start_offset = line.find("{\"id\"")
                         self.draft_log.info(line)
@@ -423,7 +415,10 @@ class ArenaScanner:
 
                             pack = int(json_find("Pack", draft_data))
                             pick = int(json_find("Pick", draft_data))
-                            card = str(json_find("GrpIds", draft_data)[0])
+                            if "GrpIds" in entry_string:
+                                card = json_find("GrpIds", draft_data)[0]
+                            else:
+                                card = str(json_find("GrpId", draft_data))
 
                             pack_index = (pick - 1) % 8
 
@@ -450,7 +445,6 @@ class ArenaScanner:
         '''Parse the premier draft string that contains the non-P1P1 pack data'''
         offset = self.pack_offset
         draft_data = object()
-        draft_string = "[UnityCrossThreadLogger]Draft.Notify "
         pack_cards = []
         pack = 0
         pick = 0
@@ -465,9 +459,7 @@ class ArenaScanner:
                         break
                     offset = log.tell()
 
-                    string_offset = line.find(draft_string)
-
-                    if string_offset != -1:
+                    if detect_string(line, [constants.DRAFT_PACK_STRING_PREMIER]) != -1:
                         self.pack_offset = offset
                         start_offset = line.find("{\"draftId\"")
                         self.draft_log.info(line)
@@ -513,7 +505,6 @@ class ArenaScanner:
         '''Parse the premier draft string that contains the non-P1P1 pack data'''
         offset = self.pack_offset
         draft_data = object()
-        draft_string = "[UnityCrossThreadLogger]Draft.Notify "
         pack_cards = []
         pack = 0
         pick = 0
@@ -528,14 +519,13 @@ class ArenaScanner:
                         break
                     offset = log.tell()
 
-                    string_offset = line.find(draft_string)
-
+                    string_offset = detect_string(line, [constants.DRAFT_PACK_STRING_PREMIER])
                     if string_offset != -1:
                         self.pack_offset = offset
                         self.draft_log.info(line)
                         pack_cards = []
                         # Identify the pack
-                        draft_data = json.loads(line[len(draft_string):])
+                        draft_data = json.loads(line[string_offset:])
                         try:
 
                             cards = str(draft_data["PackCards"]).split(',')
@@ -575,7 +565,6 @@ class ArenaScanner:
         '''Parse the premier draft string that contains the player pick data'''
         offset = self.pick_offset
         draft_data = object()
-        draft_string = "[UnityCrossThreadLogger]==> Draft.MakeHumanDraftPick "
         pack = 0
         pick = 0
         # Identify and print out the log lines that contain the draft packs
@@ -589,14 +578,13 @@ class ArenaScanner:
                         break
                     offset = log.tell()
 
-                    string_offset = line.find(draft_string)
-
+                    string_offset = detect_string(line, [constants.DRAFT_PICK_STRING_PREMIER_OLD])
                     if string_offset != -1:
                         self.draft_log.info(line)
                         self.pick_offset = offset
                         try:
                             # Identify the pack
-                            draft_data = json.loads(line[len(draft_string):])
+                            draft_data = json.loads(line[string_offset:])
 
                             request_data = json.loads(draft_data["request"])
                             param_data = request_data["params"]
@@ -631,7 +619,6 @@ class ArenaScanner:
         '''Parse the quick draft string that contains the current pack data'''
         offset = self.pack_offset
         draft_data = object()
-        draft_string = "DraftPack"
         pack_cards = []
         pack = 0
         pick = 0
@@ -646,9 +633,7 @@ class ArenaScanner:
                         break
                     offset = log.tell()
 
-                    string_offset = line.find(draft_string)
-
-                    if string_offset != -1:
+                    if detect_string(line, [constants.DRAFT_PACK_STRING_QUICK]) != -1:
                         self.pack_offset = offset
                         # Remove any prefix (e.g. log timestamp)
                         start_offset = line.find("{\"CurrentModule\"")
@@ -661,7 +646,7 @@ class ArenaScanner:
                         if draft_status == "PickNext":
                             pack_cards = []
                             try:
-                                cards = json_find("DraftPack", draft_data)
+                                cards = json_find(constants.DRAFT_PACK_STRING_QUICK, draft_data)
 
                                 for card in cards:
                                     pack_cards.append(str(card))
@@ -682,6 +667,12 @@ class ArenaScanner:
                                 self.current_pack = pack
                                 self.current_pick = pick
 
+                                # Transfer "PickedCards" to taken_cards if the previous picks were missed
+                                if not self.taken_cards:
+                                    picks = json_find("PickedCards", draft_data)
+                                    if picks:
+                                        self.taken_cards.extend(picks)
+
                                 if self.step_through:
                                     break
 
@@ -697,7 +688,6 @@ class ArenaScanner:
         '''Parse the quick draft string that contains the player pick data'''
         offset = self.pick_offset
         draft_data = object()
-        draft_string = "[UnityCrossThreadLogger]==> BotDraftDraftPick "
         pack = 0
         pick = 0
         # Identify and print out the log lines that contain the draft packs
@@ -711,19 +701,21 @@ class ArenaScanner:
                         break
                     offset = log.tell()
 
-                    string_offset = line.find(draft_string)
-
+                    string_offset = detect_string(line, [constants.DRAFT_PICK_STRING_QUICK])
                     if string_offset != -1:
                         self.draft_log.info(line)
                         self.pick_offset = offset
                         try:
                             # Identify the pack
-                            entry_string = line[string_offset+len(draft_string):]
+                            entry_string = line[string_offset:]
                             draft_data = process_json(entry_string)
 
                             pack = int(json_find("PackNumber", draft_data)) + 1
                             pick = int(json_find("PickNumber", draft_data)) + 1
-                            card = str(json_find("CardIds", draft_data))
+                            if "CardIds" in entry_string:
+                                card = json_find("CardIds", draft_data)[0]
+                            else:
+                                card = str(json_find("CardId", draft_data))
 
                             pack_index = (pick - 1) % 8
 
@@ -733,9 +725,9 @@ class ArenaScanner:
                             self.previous_picked_pack = pack
                             self.current_picked_pick = pick
 
-                            self.picked_cards[pack_index].append(card[2:7])
-                            self.taken_cards.append(card[2:7])
-                            
+                            self.picked_cards[pack_index].append(card)
+                            self.taken_cards.append(card)
+
                             if self.step_through:
                                 break
 
@@ -749,7 +741,6 @@ class ArenaScanner:
         '''Parse the traditional draft string that contains the P1P1 pack data'''
         offset = self.pack_offset
         draft_data = object()
-        draft_string = "CardsInPack"
         pack_cards = []
         pack = 0
         pick = 0
@@ -764,9 +755,7 @@ class ArenaScanner:
                         break
                     offset = log.tell()
 
-                    string_offset = line.find(draft_string)
-
-                    if string_offset != -1:
+                    if detect_string(line, [constants.DRAFT_P1P1_STRING_PREMIER]) != -1:
                         # Remove any prefix (e.g. log timestamp)
                         start_offset = line.find("{\"id\":")
                         self.draft_log.info(line)
@@ -776,7 +765,7 @@ class ArenaScanner:
                         pack_cards = []
                         try:
 
-                            cards = json_find("CardsInPack", draft_data)
+                            cards = json_find(constants.DRAFT_P1P1_STRING_PREMIER, draft_data)
 
                             for card in cards:
                                 pack_cards.append(str(card))
@@ -818,7 +807,6 @@ class ArenaScanner:
         '''Parse the traditional draft string that contains the player pick data'''
         offset = self.pick_offset
         draft_data = object()
-        draft_string = "[UnityCrossThreadLogger]==> EventPlayerDraftMakePick "
         pack = 0
         pick = 0
         # Identify and print out the log lines that contain the draft packs
@@ -832,9 +820,7 @@ class ArenaScanner:
                         break
                     offset = log.tell()
 
-                    string_offset = line.find(draft_string)
-
-                    if string_offset != -1:
+                    if detect_string(line, [constants.DRAFT_PICK_STRING_PREMIER]) != -1:
                         self.pick_offset = offset
                         start_offset = line.find("{\"id\"")
                         self.draft_log.info(line)
@@ -846,7 +832,10 @@ class ArenaScanner:
 
                             pack = int(json_find("Pack", draft_data))
                             pick = int(json_find("Pick", draft_data))
-                            card = str(json_find("GrpIds", draft_data)[0])
+                            if "GrpIds" in entry_string:
+                                card = json_find("GrpIds", draft_data)[0]
+                            else:
+                                card = str(json_find("GrpId", draft_data))
 
                             pack_index = (pick - 1) % 8
 
@@ -873,7 +862,6 @@ class ArenaScanner:
         '''Parse the quick draft string that contains the non-P1P1 pack data'''
         offset = self.pack_offset
         draft_data = object()
-        draft_string = "[UnityCrossThreadLogger]Draft.Notify "
         pack_cards = []
         pack = 0
         pick = 0
@@ -888,9 +876,7 @@ class ArenaScanner:
                         break
                     offset = log.tell()
 
-                    string_offset = line.find(draft_string)
-
-                    if string_offset != -1:
+                    if detect_string(line, [constants.DRAFT_PACK_STRING_PREMIER]) != -1:
                         self.pack_offset = offset
                         start_offset = line.find("{\"draftId\"")
                         self.draft_log.info(line)
@@ -1008,7 +994,7 @@ class ArenaScanner:
                     set_code = file[0]
                     event_type = file[1]
                     user_group = file[2]
-                    location = file[5]
+                    location = file[6]
                     # Alchemy sets use the [Y##]{event_type} ({user_group}) naming scheme and everything else uses <event_type> ({user_group}) scheme
                     type_string = f"[{set_code[0:3]}]{event_type} ({user_group})" if re.findall(r"^[Yy]\d{2}", set_code) else f"{event_type} ({user_group})"
                     data_sources[type_string] = location

--- a/tests/test_limited_sets.py
+++ b/tests/test_limited_sets.py
@@ -484,3 +484,5 @@ def test_substitute_string_date_shift(mock_urlopen, limited_sets):
     # Verify that the {DATESHIFT} response is substituted for the expected shift date 
     assert "Arena Cube" in output_sets.data
     assert output_sets.data["Arena Cube"].start_date == expected_shift_date
+    
+

--- a/tests/test_log_scanner.py
+++ b/tests/test_log_scanner.py
@@ -13,7 +13,7 @@ TEST_SETS_DIRECTORY = os.path.join(os.getcwd(), "tests","data")
 
 OTJ_PREMIER_SNAPSHOT = os.path.join(os.getcwd(), "tests", "data","OTJ_PremierDraft_Data_2024_5_3.json")
 
-OTJ_EVENT_ENTRY = r'[UnityCrossThreadLogger]==> EventJoin {"id":"11a8f74b-1afb-4d25-bb35-55d43674c808","request":"{\"EventName\":\"PremierDraft_OTJ_20240416\",\"EntryCurrencyType\":\"Gem\",\"EntryCurrencyPaid\":1500,\"CustomTokenId\":null}"}'
+OTJ_EVENT_ENTRY = r'[UnityCrossThreadLogger]==> Event_Join {"id":"11a8f74b-1afb-4d25-bb35-55d43674c808","request":"{\"EventName\":\"PremierDraft_OTJ_20240416\",\"EntryCurrencyType\":\"Gem\",\"EntryCurrencyPaid\":1500,\"CustomTokenId\":null}"}'
 OTJ_P1P1_ENTRY = r'[UnityCrossThreadLogger]==> LogBusinessEvents {"id":"a5515a1a-d96e-4da3-9a4a-c03cc4b2b938","request":"{\"PlayerId\":null,\"ClientPlatform\":null,\"DraftId\":\"87b408d1-43e0-4fb5-8c74-a1227fde087c\",\"EventId\":\"PremierDraft_OTJ_20240416\",\"SeatNumber\":1,\"PackNumber\":1,\"PickNumber\":1,\"PickGrpId\":90459,\"CardsInPack\":[90734,90584,90631,90362,90440,90349,90486,90527,90406,90439,90488,90480,90388,90459],\"AutoPick\":false,\"TimeRemainingOnPick\":63.99701,\"EventType\":24,\"EventTime\":\"2024-05-08T00:56:34.4223433Z\"}"}'
 OTJ_P1P1_CARD_NAMES =[
     "Back for More",
@@ -33,6 +33,7 @@ OTJ_P1P1_CARD_NAMES =[
 OTJ_P1P2_ENTRY_SKIP = r'[UnityCrossThreadLogger]==> LogBusinessEvents {"id":"972efef7-cd60-4254-ae18-634210287c95","request":"{\"PlayerId\":null,\"ClientPlatform\":null,\"DraftId\":\"87b408d1-43e0-4fb5-8c74-a1257fde087c\",\"EventId\":\"PremierDraft_OTJ_20240416\",\"SeatNumber\":1,\"PackNumber\":1,\"PickNumber\":2,\"PickGrpId\":90701,\"CardsInPack\":[90702,90417,90607,90524,90481,90588,90440,90418,90353,90494,90360,90609,90548],\"AutoPick\":false,\"TimeRemainingOnPick\":30.8176479,\"EventType\":24,\"EventTime\":\"2024-05-08T00:57:07.6027017Z\"}"}'
 
 TEST_SETS = SetDictionary(data={
+    "TDM" : SetInfo(seventeenlands=["TDM"]),
     "DSK" : SetInfo(seventeenlands=["DSK"]),
     "MH3" : SetInfo(seventeenlands=["MH3"]),
     "OTJ" : SetInfo(seventeenlands=["OTJ"]),
@@ -74,514 +75,742 @@ class EventResults:
     card_pool: List[str] = Field(default_factory=list)
     missing: List[str] = Field(default_factory=list)
 
+# Premier draft log entries collected from Player.log after the 2025-4-8 Arena Update
+TDM_PREMIER_DRAFT_ENTRIES_2025_4_8 = [
+    (
+        "Event Start",
+        EventResults(
+            new_event=True,
+            data_update=False,
+            current_set="TDM",
+            current_event="PremierDraft",
+            current_pack=0,
+            current_pick=0,
+            picks=[],
+            pack=[],
+            card_pool=[],
+            missing=[],
+        ),
+        r'[UnityCrossThreadLogger]==> EventJoin {"id":"d39f27d5-23c9-4ffd-b5d3-888c9bbccd97","request":"{\"EventName\":\"PremierDraft_TDM_20250408\",\"EntryCurrencyType\":\"Gold\",\"EntryCurrencyPaid\":10000,\"CustomTokenId\":null}"}'
+    ),
+    (
+        "P1P1 - Pack",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="TDM",
+            current_event="PremierDraft",
+            current_pack=1,
+            current_pick=1,
+            picks=[],
+            pack=["95536","95586","95574","95615","95544","95742","95640","95663","95732","95635","95700","95561","95606","95804"], 
+            card_pool=[],
+            missing=[],
+        ),
+        r'[UnityCrossThreadLogger]==> LogBusinessEvents {"id":"ee35cead-cddb-4ef0-919e-eb0fe92097b5","request":"{\"PlayerId\":null,\"ClientPlatform\":null,\"DraftId\":\"395f747c-07a0-4aed-8bb2-a4b399b24bb5\",\"EventId\":\"PremierDraft_TDM_20250408\",\"SeatNumber\":5,\"PackNumber\":1,\"PickNumber\":1,\"PickGrpId\":95606,\"PickGrpIds\":[95606],\"CardsInPack\":[95536,95586,95574,95615,95544,95742,95640,95663,95732,95635,95700,95561,95606,95804],\"AutoPick\":false,\"TimeRemainingOnPick\":58.92359,\"EventType\":24,\"EventTime\":\"2025-04-19T14:45:33.8146729Z\"}"}'
+    ),    
+    (
+        "P1P1 - Pick",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="TDM",
+            current_event="PremierDraft",
+            current_pack=1,
+            current_pick=1,
+            picks=["95606"],
+            pack=["95536","95586","95574","95615","95544","95742","95640","95663","95732","95635","95700","95561","95606","95804"], 
+            card_pool=["95606"],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]==> EventPlayerDraftMakePick {"id":"85c3c7c3-37be-49f3-8b6a-1bfe03bda027","request":"{\"DraftId\":\"395f747c-07a0-4aed-8bb2-a4b399b24bb5\",\"GrpId\":0,\"GrpIds\":[95606],\"Pack\":1,\"Pick\":1}"}'
+    ),
+    (
+        "P1P2 - Pack",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="TDM",
+            current_event="PremierDraft",
+            current_pack=1,
+            current_pick=2,
+            picks=[],
+            pack=["95742","95678","95533","95624","95741","95627","95587","95572","95665","95546","95611","95781","95798"],
+            card_pool=["95606"],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]Draft.Notify {"draftId":"395f747c-07a0-4aed-8bb2-a4b399b24bb5","SelfPick":2,"SelfPack":1,"PackCards":"95742,95678,95533,95624,95741,95627,95587,95572,95665,95546,95611,95781,95798"}'
+    ),
+]
+
 # Premier draft log entries collected from Player.log after 2024-5-7 Arena update
 OTJ_PREMIER_DRAFT_ENTRIES_2024_5_7 = [
-    ("Event Start",
-    EventResults(new_event=True,
-                 data_update=False,
-                 current_set="OTJ",
-                 current_event="PremierDraft",
-                 current_pack=0,
-                 current_pick=0,
-                 picks=[],
-                 pack=[],
-                 card_pool=[],
-                 missing=[]),
-    OTJ_EVENT_ENTRY
+    (
+        "Event Start",
+        EventResults(
+            new_event=True,
+            data_update=False,
+            current_set="OTJ",
+            current_event="PremierDraft",
+            current_pack=0,
+            current_pick=0,
+            picks=[],
+            pack=[],
+            card_pool=[],
+            missing=[],
+        ),
+        OTJ_EVENT_ENTRY
     ),
-    ("P1P1 - Pack",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="OTJ",
-                 current_event="PremierDraft",
-                 current_pack=1,
-                 current_pick=1,
-                 picks=[],
-                 pack=["90734","90584","90631","90362","90440","90349","90486","90527","90406","90439","90488","90480","90388","90459"], 
-                 card_pool=[],
-                 missing=[]),
-    OTJ_P1P1_ENTRY
+    (
+        "P1P1 - Pack",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="OTJ",
+            current_event="PremierDraft",
+            current_pack=1,
+            current_pick=1,
+            picks=[],
+            pack=["90734","90584","90631","90362","90440","90349","90486","90527","90406","90439","90488","90480","90388","90459"], 
+            card_pool=[],
+            missing=[],
+        ),
+        OTJ_P1P1_ENTRY
     ),
-    ("P1P1 - Pick",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="OTJ",
-                 current_event="PremierDraft",
-                 current_pack=1,
-                 current_pick=1,
-                 picks=["90459"],
-                 pack=["90734","90584","90631","90362","90440","90349","90486","90527","90406","90439","90488","90480","90388","90459"],
-                 card_pool=["90459"],
-                 missing=[]),
-    r'[UnityCrossThreadLogger]==> EventPlayerDraftMakePick {"id":"a14a9a98-f408-4051-8799-50df13eb18ad","request":"{\"DraftId\":\"87b408d1-43e0-4fb5-8c74-a1257fde387c\",\"GrpIds\":[90459],\"Pack\":1,\"Pick\":1}"}'
+    (
+        "P1P1 - Pick",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="OTJ",
+            current_event="PremierDraft",
+            current_pack=1,
+            current_pick=1,
+            picks=["90459"],
+            pack=["90734","90584","90631","90362","90440","90349","90486","90527","90406","90439","90488","90480","90388","90459"],
+            card_pool=["90459"],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]==> Event_PlayerDraftMakePick {"id":"a14a9a98-f408-4051-8799-50df13eb18ad","request":"{\"DraftId\":\"87b408d1-43e0-4fb5-8c74-a1257fde387c\",\"GrpId\":90459,\"Pack\":1,\"Pick\":1}"}'
     ),
-    ("P1P2 - Pack",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="OTJ",
-                 current_event="PremierDraft",
-                 current_pack=1,
-                 current_pick=2,
-                 picks=[],
-                 pack=["90701","90416","90606","90524","90481","90588","90440","90418","90353","90494","90360","90609","90548"],
-                 card_pool=["90459"],
-                 missing=[]),
-    r'[UnityCrossThreadLogger]Draft.Notify {"draftId":"87b408d1-43e0-4fb5-8c74-a1257fde017c","SelfPick":2,"SelfPack":1,"PackCards":"90701,90416,90606,90524,90481,90588,90440,90418,90353,90494,90360,90609,90548"}'
+    (
+        "P1P2 - Pack",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="OTJ",
+            current_event="PremierDraft",
+            current_pack=1,
+            current_pick=2,
+            picks=[],
+            pack=["90701","90416","90606","90524","90481","90588","90440","90418","90353","90494","90360","90609","90548"],
+            card_pool=["90459"],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]Draft.Notify {"draftId":"87b408d1-43e0-4fb5-8c74-a1257fde017c","SelfPick":2,"SelfPack":1,"PackCards":"90701,90416,90606,90524,90481,90588,90440,90418,90353,90494,90360,90609,90548"}'
     ),
-    ("P1P2 - Pack Skip Repeat",
-    EventResults(new_event=False,
-                 data_update=False,
-                 current_set="OTJ",
-                 current_event="PremierDraft",
-                 current_pack=1,
-                 current_pick=2,
-                 picks=[],
-                 pack=["90701","90416","90606","90524","90481","90588","90440","90418","90353","90494","90360","90609","90548"],
-                 card_pool=["90459"],
-                 missing=[]),
-    OTJ_P1P2_ENTRY_SKIP
+    (
+        "P1P2 - Pack Skip Repeat",
+        EventResults(
+            new_event=False,
+            data_update=False,
+            current_set="OTJ",
+            current_event="PremierDraft",
+            current_pack=1,
+            current_pick=2,
+            picks=[],
+            pack=["90701","90416","90606","90524","90481","90588","90440","90418","90353","90494","90360","90609","90548"],
+            card_pool=["90459"],
+            missing=[]
+        ),
+        OTJ_P1P2_ENTRY_SKIP
     ),
-    ("P1P9 - Pack",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="OTJ",
-                 current_event="PremierDraft",
-                 current_pack=1,
-                 current_pick=9,
-                 picks=["90459"],
-                 pack=["90631","90349","90486","90406","90488","90480"],
-                 card_pool=["90459"],
-                 missing=["90734","90584","90362","90440","90527","90439","90388","90459"]),
-    r'[UnityCrossThreadLogger]Draft.Notify {"draftId":"87b108d1-43e0-4fb5-8c74-a1257fde087c","SelfPick":9,"SelfPack":1,"PackCards":"90631,90349,90486,90406,90488,90480"}'
+    (
+        "P1P9 - Pack",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="OTJ",
+            current_event="PremierDraft",
+            current_pack=1,
+            current_pick=9,
+            picks=["90459"],
+            pack=["90631","90349","90486","90406","90488","90480"],
+            card_pool=["90459"],
+            missing=["90734","90584","90362","90440","90527","90439","90388","90459"]
+        ),
+        r'[UnityCrossThreadLogger]Draft.Notify {"draftId":"87b108d1-43e0-4fb5-8c74-a1257fde087c","SelfPick":9,"SelfPack":1,"PackCards":"90631,90349,90486,90406,90488,90480"}'
     ),
-    ("P3P14 - Pack",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="OTJ",
-                 current_event="PremierDraft",
-                 current_pack=3,
-                 current_pick=14,
-                 picks=[],
-                 pack=["90625"],
-                 card_pool=["90459"],
-                 missing=[]),
-    r'[UnityCrossThreadLogger]Draft.Notify {"draftId":"87b408d1-43e0-4fb5-8c74-a1257fde087c","SelfPick":14,"SelfPack":3,"PackCards":"90625"}'
+    (
+        "P3P14 - Pack",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="OTJ",
+            current_event="PremierDraft",
+            current_pack=3,
+            current_pick=14,
+            picks=[],
+            pack=["90625"],
+            card_pool=["90459"],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]Draft.Notify {"draftId":"87b408d1-43e0-4fb5-8c74-a1257fde087c","SelfPick":14,"SelfPack":3,"PackCards":"90625"}'
     )
 ]
 
 # Premier draft log entries collected from Player.log before 2024-5-7 Arena update
 MKM_PREMIER_DRAFT_ENTRIES = [
-    ("Event Start",
-    EventResults(new_event=True,
-                 data_update=False,
-                 current_set="MKM",
-                 current_event="PremierDraft",
-                 current_pack=0,
-                 current_pick=0,
-                 picks=[],
-                 pack=[],
-                 card_pool=[],
-                 missing=[]),
-    r'[UnityCrossThreadLogger]==> EventJoin {"id":"4adb764e-3c33-46a9-91e6-4393bc7a5895","request":"{\"Type\":600,\"TransId\":\"4adb764e-3c33-46a9-91e6-4393bc7a5895\",\"Payload\":\"{\\\"EventName\\\":\\\"PremierDraft_MKM_20240206\\\",\\\"EntryCurrencyType\\\":\\\"Gold\\\",\\\"EntryCurrencyPaid\\\":10000,\\\"CustomTokenId\\\":null}\"}"}'
+    (
+        "Event Start",
+        EventResults(
+            new_event=True,
+            data_update=False,
+            current_set="MKM",
+            current_event="PremierDraft",
+            current_pack=0,
+            current_pick=0,
+            picks=[],
+            pack=[],
+            card_pool=[],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]==> Event_Join {"id":"4adb764e-3c33-46a9-91e6-4393bc7a5895","request":"{\"Type\":600,\"TransId\":\"4adb764e-3c33-46a9-91e6-4393bc7a5895\",\"Payload\":\"{\\\"EventName\\\":\\\"PremierDraft_MKM_20240206\\\",\\\"EntryCurrencyType\\\":\\\"Gold\\\",\\\"EntryCurrencyPaid\\\":10000,\\\"CustomTokenId\\\":null}\"}"}'
     ),
-    ("P1P1 - Pack",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="MKM",
-                 current_event="PremierDraft",
-                 current_pack=1,
-                 current_pick=1,
-                 picks=[],
-                 pack=["89119","89040","89008","88926","89093","88981","88950","89158","89105","89194","88994","88989","88931"],
-                 card_pool=[],
-                 missing=[]),
-    r'[UnityCrossThreadLogger]==> LogBusinessEvents {"id":"a5c18703-d17d-4ec0-8c81-d5a6ba0ffd31","request":"{\"Type\":1912,\"TransId\":\"a5c18703-d17d-4ec0-8c81-d5a6ba0ffd31\",\"Payload\":\"{\\\"PlayerId\\\":null,\\\"ClientPlatform\\\":null,\\\"DraftId\\\":\\\"bc95b8cb-04d4-4823-aa37-a9b1a1212cb6\\\",\\\"EventId\\\":\\\"PremierDraft_MKM_20240206\\\",\\\"SeatNumber\\\":5,\\\"PackNumber\\\":1,\\\"PickNumber\\\":1,\\\"PickGrpId\\\":89119,\\\"CardsInPack\\\":[89119,89040,89008,88926,89093,88981,88950,89158,89105,89194,88994,88989,88931],\\\"AutoPick\\\":false,\\\"TimeRemainingOnPick\\\":58.9969749,\\\"EventType\\\":24,\\\"EventTime\\\":\\\"2024-02-13T09:53:59.9980573Z\\\"}\"}"}'
+    (
+        "P1P1 - Pack",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="MKM",
+            current_event="PremierDraft",
+            current_pack=1,
+            current_pick=1,
+            picks=[],
+            pack=["89119","89040","89008","88926","89093","88981","88950","89158","89105","89194","88994","88989","88931"],
+            card_pool=[],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]==> LogBusinessEvents {"id":"a5c18703-d17d-4ec0-8c81-d5a6ba0ffd31","request":"{\"Type\":1912,\"TransId\":\"a5c18703-d17d-4ec0-8c81-d5a6ba0ffd31\",\"Payload\":\"{\\\"PlayerId\\\":null,\\\"ClientPlatform\\\":null,\\\"DraftId\\\":\\\"bc95b8cb-04d4-4823-aa37-a9b1a1212cb6\\\",\\\"EventId\\\":\\\"PremierDraft_MKM_20240206\\\",\\\"SeatNumber\\\":5,\\\"PackNumber\\\":1,\\\"PickNumber\\\":1,\\\"PickGrpId\\\":89119,\\\"CardsInPack\\\":[89119,89040,89008,88926,89093,88981,88950,89158,89105,89194,88994,88989,88931],\\\"AutoPick\\\":false,\\\"TimeRemainingOnPick\\\":58.9969749,\\\"EventType\\\":24,\\\"EventTime\\\":\\\"2024-02-13T09:53:59.9980573Z\\\"}\"}"}'
     ),
-    ("P1P1 - Pick",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="MKM",
-                 current_event="PremierDraft",
-                 current_pack=1,
-                 current_pick=1,
-                 picks=["89119"],
-                 pack=["89119","89040","89008","88926","89093","88981","88950","89158","89105","89194","88994","88989","88931"],
-                 card_pool=["89119"],
-                 missing=[]),
-    r'[UnityCrossThreadLogger]==> EventPlayerDraftMakePick {"id":"49311e08-14e2-4ef0-b532-cff8ac3850dc","request":"{\"Type\":620,\"TransId\":\"49311e08-14e2-4ef0-b532-cff8ac3850dc\",\"Payload\":\"{\\\"DraftId\\\":\\\"bc95b8cb-04d4-4823-aa37-a9b1a1212cb6\\\",\\\"GrpIds\\\":[89119],\\\"Pack\\\":1,\\\"Pick\\\":1}\"}"}'
+    (
+        "P1P1 - Pick",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="MKM",
+            current_event="PremierDraft",
+            current_pack=1,
+            current_pick=1,
+            picks=["89119"],
+            pack=["89119","89040","89008","88926","89093","88981","88950","89158","89105","89194","88994","88989","88931"],
+            card_pool=["89119"],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]==> Event_PlayerDraftMakePick {"id":"49311e08-14e2-4ef0-b532-cff8ac3850dc","request":"{\"Type\":620,\"TransId\":\"49311e08-14e2-4ef0-b532-cff8ac3850dc\",\"Payload\":\"{\\\"DraftId\\\":\\\"bc95b8cb-04d4-4823-aa37-a9b1a1212cb6\\\",\\\"GrpId\\\":89119,\\\"Pack\\\":1,\\\"Pick\\\":1}\"}"}'
     ),
-    ("P1P2 - Pack",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="MKM",
-                 current_event="PremierDraft",
-                 current_pack=1,
-                 current_pick=2,
-                 picks=[],
-                 pack=["89097","89106","89057","88981","88934","89116","89004","88941","89035","89101","89127","89040"],
-                 card_pool=["89119"],
-                 missing=[]),
-    r'[UnityCrossThreadLogger]Draft.Notify {"draftId":"bc95b8cb-04d4-4823-aa37-a9b1a1212cb6","SelfPick":2,"SelfPack":1,"PackCards":"89097,89106,89057,88981,88934,89116,89004,88941,89035,89101,89127,89040"}'
+    (
+        "P1P2 - Pack",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="MKM",
+            current_event="PremierDraft",
+            current_pack=1,
+            current_pick=2,
+            picks=[],
+            pack=["89097","89106","89057","88981","88934","89116","89004","88941","89035","89101","89127","89040"],
+            card_pool=["89119"],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]Draft.Notify {"draftId":"bc95b8cb-04d4-4823-aa37-a9b1a1212cb6","SelfPick":2,"SelfPack":1,"PackCards":"89097,89106,89057,88981,88934,89116,89004,88941,89035,89101,89127,89040"}'
     ),
-    ("P1P9 - Pack",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="MKM",
-                 current_event="PremierDraft",
-                 current_pack=1,
-                 current_pick=9,
-                 picks=["89119"],
-                 pack=["89040","89008","88981","89158","88989"],
-                 card_pool=["89119"],
-                 missing=["89119","88926","89093","88950","89105","89194","88994","88931"]),
-    r'[UnityCrossThreadLogger]Draft.Notify {"draftId":"bc95b8cb-04d4-4823-aa37-a9b1a1212cb6","SelfPick":9,"SelfPack":1,"PackCards":"89040,89008,88981,89158,88989"}'
+    (
+        "P1P9 - Pack",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="MKM",
+            current_event="PremierDraft",
+            current_pack=1,
+            current_pick=9,
+            picks=["89119"],
+            pack=["89040","89008","88981","89158","88989"],
+            card_pool=["89119"],
+            missing=["89119","88926","89093","88950","89105","89194","88994","88931"]
+        ),
+        r'[UnityCrossThreadLogger]Draft.Notify {"draftId":"bc95b8cb-04d4-4823-aa37-a9b1a1212cb6","SelfPick":9,"SelfPack":1,"PackCards":"89040,89008,88981,89158,88989"}'
     )
 ]
 
 # Quick draft log entries collected from Player.log before 2024-5-7 Arena update
 OTJ_QUICK_DRAFT_ENTRIES = [
-    ("Event Start",
-    EventResults(new_event=True,
-                 data_update=False,
-                 current_set="OTJ",
-                 current_event="QuickDraft",
-                 current_pack=0,
-                 current_pick=0,
-                 picks=[],
-                 pack=[],
-                 card_pool=[],
-                 missing=[]),
-    r'[UnityCrossThreadLogger]==> BotDraft_DraftStatus {"id":"acd4c04b-fabcd-4c5c-ac1e-6dfb53a2df2f","request":"{\"Type\":1802,\"TransId\":\"acd4c04b-fabcd-4c5c-ac1e-6dfb53a2df2f\",\"Payload\":\"{\\\"EventName\\\":\\\"QuickDraft_OTJ_20240426\\\"}\"}"}'
+    (
+        "Event Start",
+        EventResults(
+            new_event=True,
+            data_update=False,
+            current_set="OTJ",
+            current_event="QuickDraft",
+            current_pack=0,
+            current_pick=0,
+            picks=[],
+            pack=[],
+            card_pool=[],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]==> BotDraft_DraftStatus {"id":"acd4c04b-fabcd-4c5c-ac1e-6dfb53a2df2f","request":"{\"Type\":1802,\"TransId\":\"acd4c04b-fabcd-4c5c-ac1e-6dfb53a2df2f\",\"Payload\":\"{\\\"EventName\\\":\\\"QuickDraft_OTJ_20240426\\\"}\"}"}'
     ),
-    ("P1P1 - Pack",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="OTJ",
-                 current_event="QuickDraft",
-                 current_pack=1,
-                 current_pick=1,
-                 picks=[],
-                 pack=["90711","90504","90627","90449","90376","90595","90489","90527","90401","90365","90426","90480","90439","90428"],
-                 card_pool=[],
-                 missing=[]),
-    r'{"CurrentModule":"BotDraft","Payload":"{\"Result\":\"Success\",\"EventName\":\"QuickDraft_OTJ_20240426\",\"DraftStatus\":\"PickNext\",\"PackNumber\":0,\"PickNumber\":0,\"DraftPack\":[\"90711\",\"90504\",\"90627\",\"90449\",\"90376\",\"90595\",\"90489\",\"90527\",\"90401\",\"90365\",\"90426\",\"90480\",\"90439\",\"90428\"],\"PackStyles\":[],\"PickedCards\":[],\"PickedStyles\":[]}"}'
+    (
+        "P1P1 - Pack",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="OTJ",
+            current_event="QuickDraft",
+            current_pack=1,
+            current_pick=1,
+            picks=[],
+            pack=["90711","90504","90627","90449","90376","90595","90489","90527","90401","90365","90426","90480","90439","90428"],
+            card_pool=[],
+            missing=[]
+        ),
+        r'{"CurrentModule":"BotDraft","Payload":"{\"Result\":\"Success\",\"EventName\":\"QuickDraft_OTJ_20240426\",\"DraftStatus\":\"PickNext\",\"PackNumber\":0,\"PickNumber\":0,\"DraftPack\":[\"90711\",\"90504\",\"90627\",\"90449\",\"90376\",\"90595\",\"90489\",\"90527\",\"90401\",\"90365\",\"90426\",\"90480\",\"90439\",\"90428\"],\"PackStyles\":[],\"PickedCards\":[],\"PickedStyles\":[]}"}'
     ),
-    ("P1P1 - Pick",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="OTJ",
-                 current_event="QuickDraft",
-                 current_pack=1,
-                 current_pick=1,
-                 picks=["90428"],
-                 pack=["90711","90504","90627","90449","90376","90595","90489","90527","90401","90365","90426","90480","90439","90428"],
-                 card_pool=["90428"],
-                 missing=[]),
-    r'[UnityCrossThreadLogger]==> BotDraftDraftPick {"id":"8ef75393-f84d-4aea-9baa-805c7d9cdb68","request":"{\"Type\":1801,\"TransId\":\"8ef75393-f84d-4aea-9baa-805c7d9cdb68\",\"Payload\":\"{\\\"EventName\\\":\\\"QuickDraft_OTJ_20240426\\\",\\\"PickInfo\\\":{\\\"EventName\\\":\\\"QuickDraft_OTJ_20240426\\\",\\\"CardIds\\\":[\\\"90428\\\"],\\\"PackNumber\\\":0,\\\"PickNumber\\\":0}}\"}"}'
+    (
+        "P1P1 - Pick",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="OTJ",
+            current_event="QuickDraft",
+            current_pack=1,
+            current_pick=1,
+            picks=["90428"],
+            pack=["90711","90504","90627","90449","90376","90595","90489","90527","90401","90365","90426","90480","90439","90428"],
+            card_pool=["90428"],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]==> BotDraft_DraftPick {"id":"8ef75393-f84d-4aea-9baa-805c7d9cdb68","request":"{\"Type\":1801,\"TransId\":\"8ef75393-f84d-4aea-9baa-805c7d9cdb68\",\"Payload\":\"{\\\"EventName\\\":\\\"QuickDraft_OTJ_20240426\\\",\\\"PickInfo\\\":{\\\"EventName\\\":\\\"QuickDraft_OTJ_20240426\\\",\\\"CardId\\\":\\\"90428\\\",\\\"PackNumber\\\":0,\\\"PickNumber\\\":0}}\"}"}'
     ),
-    ("P1P2 - Pack",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="OTJ",
-                 current_event="QuickDraft",
-                 current_pack=1,
-                 current_pick=2,
-                 picks=[],
-                 pack=["90586","90628","90499","90600","90468","90418","90449","90442","90363","90360","90405","90598","90548"],
-                 card_pool=["90428"],
-                 missing=[]),
-    r'{"CurrentModule":"BotDraft","Payload":"{\"Result\":\"Success\",\"EventName\":\"QuickDraft_OTJ_20240426\",\"DraftStatus\":\"PickNext\",\"PackNumber\":0,\"PickNumber\":1,\"DraftPack\":[\"90586\",\"90628\",\"90499\",\"90600\",\"90468\",\"90418\",\"90449\",\"90442\",\"90363\",\"90360\",\"90405\",\"90598\",\"90548\"],\"PackStyles\":[],\"PickedCards\":[\"90428\"],\"PickedStyles\":[]}","DTO_InventoryInfo":{"SeqId":5,"Changes":[],"Gems":4620,"Gold":1525,"TotalVaultProgress":271,"WildCardCommons":13,"WildCardUnCommons":28,"WildCardRares":7,"WildCardMythics":5,"CustomTokens":{"BonusPackProgress":1,"BattlePass_BRO_Orb":1,"Token_JumpIn":5,"BattlePass_WOE_Orb":1,"BattlePass_MKM_Orb":1},"Boosters":[{"CollationId":100026,"SetCode":"VOW","Count":42},{"CollationId":400026,"SetCode":"Y22MID","Count":3},{"CollationId":100024,"SetCode":"AFR","Count":2},{"CollationId":100027,"SetCode":"NEO","Count":21},{"CollationId":100025,"SetCode":"MID","Count":2},{"CollationId":100029,"SetCode":"HBG","Count":15},{"CollationId":100030,"SetCode":"DMU","Count":7},{"CollationId":100031,"SetCode":"BRO","Count":3},{"CollationId":400031,"SetCode":"Y23BRO","Count":6},{"CollationId":100032,"SetCode":"ONE","Count":4},{"CollationId":400032,"SetCode":"Y23ONE","Count":3},{"CollationId":100033,"SetCode":"SIR","Count":4},{"CollationId":100037,"SetCode":"MOM","Count":4},{"CollationId":100040,"SetCode":"WOE","Count":6},{"CollationId":100039,"SetCode":"LTR","Count":3},{"CollationId":100038,"SetCode":"MAT","Count":3},{"CollationId":400040,"SetCode":"Y24WOE","Count":3},{"CollationId":100041,"SetCode":"LCI","Count":7},{"CollationId":100042,"SetCode":"KTK","Count":3},{"CollationId":400041,"SetCode":"Y24LCI","Count":3},{"CollationId":100043,"SetCode":"MKM","Count":13},{"CollationId":100044,"SetCode":"OTJ","Count":3},{"CollationId":400043,"SetCode":"Y24MKM","Count":3}],"Vouchers":{},"Cosmetics":{"ArtStyles":[{"Type":"ArtStyle","Id":"404952.DA","ArtId":404952,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"409037.DA","ArtId":409037,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"127296.DA","ArtId":127296,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"407656.DA","ArtId":407656,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"402637.DA","ArtId":402637,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"404505.DA","ArtId":404505,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416691.SH","ArtId":416691,"Variant":"SH","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417846.JP","ArtId":417846,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421263.DA","ArtId":421263,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421270.DA","ArtId":421270,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421273.DA","ArtId":421273,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421180.DA","ArtId":421180,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421282.DA","ArtId":421282,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421308.TOHO","ArtId":421308,"Variant":"TOHO","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421132.DA","ArtId":421132,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422314.DA","ArtId":422314,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"417325.DA","ArtId":417325,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"425840.DA","ArtId":425840,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"409970.STORYBOOK","ArtId":409970,"Variant":"STORYBOOK","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"403040.ARCHITECTURE","ArtId":403040,"Variant":"ARCHITECTURE","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"430483.DA","ArtId":430483,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"438995.DA","ArtId":438995,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"430520.DA","ArtId":430520,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418126.SCHEMATIC","ArtId":418126,"Variant":"SCHEMATIC","ExplicitGrpIds":[]}],"Avatars":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_ChandraNalaar","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_AjaniGoldmane","Type":"Avatar"},{"Id":"Avatar_Basic_GideonJura","Type":"Avatar"},{"Id":"Avatar_Basic_Teferi","Type":"Avatar"},{"Id":"Avatar_Basic_SarkhanVol","Type":"Avatar"},{"Id":"Avatar_Basic_Tezzeret","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_VivienReid","Type":"Avatar"},{"Id":"Avatar_Basic_NissaRevane","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_LilianaVess","Type":"Avatar"},{"Id":"Avatar_Basic_Karn","Type":"Avatar"},{"Id":"Avatar_Basic_JayaBallard","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_JaceBeleren","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Elspeth_MOM","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Ashiok_WAR","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Kaito_NEO","Type":"Avatar"}],"Pets":[],"Sleeves":[{"Id":"CardBack_ZNR_402686","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_EmbossedDefaultArena","Type":"Sleeve"},{"Id":"CardBack_ZNR_417011","Type":"Sleeve"},{"Id":"CardBack_M21_413716","Type":"Sleeve"},{"AcquisitionFlags":"Event","Id":"CardBack_IKO_VivienMonstersAdvocate","Type":"Sleeve"},{"Id":"CardBack_DMU_439347","Type":"Sleeve"}],"Emotes":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Hello","Type":"Emote","Category":"Greeting","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Nice_Thanks","Type":"Emote","FlipType":"Reply","Category":"Kudos","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Thinking_YourGo","Type":"Emote","FlipType":"Priority","Category":"Priority","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Oops_Sorry","Type":"Emote","FlipType":"Reply","Category":"Accident","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_GoodGame","Type":"Emote","Category":"GoodGame","Treatment":""},{"Id":"Sticker_MID_Teferi","Type":"Emote","Page":"Sticker","Category":"MID_Stickers","Treatment":"Sticker_MID_Teferi"},{"Id":"Sticker_Halloween23_AngryRoll","Type":"Emote","Page":"Sticker","Category":"Halloween23_Stickers","Treatment":"Sticker_Halloween23_AngryRoll"}]}}}'
+    (
+        "P1P2 - Pack",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="OTJ",
+            current_event="QuickDraft",
+            current_pack=1,
+            current_pick=2,
+            picks=[],
+            pack=["90586","90628","90499","90600","90468","90418","90449","90442","90363","90360","90405","90598","90548"],
+            card_pool=["90428"],
+            missing=[]
+        ),
+        r'{"CurrentModule":"BotDraft","Payload":"{\"Result\":\"Success\",\"EventName\":\"QuickDraft_OTJ_20240426\",\"DraftStatus\":\"PickNext\",\"PackNumber\":0,\"PickNumber\":1,\"DraftPack\":[\"90586\",\"90628\",\"90499\",\"90600\",\"90468\",\"90418\",\"90449\",\"90442\",\"90363\",\"90360\",\"90405\",\"90598\",\"90548\"],\"PackStyles\":[],\"PickedCards\":[\"90428\"],\"PickedStyles\":[]}","DTO_InventoryInfo":{"SeqId":5,"Changes":[],"Gems":4620,"Gold":1525,"TotalVaultProgress":271,"WildCardCommons":13,"WildCardUnCommons":28,"WildCardRares":7,"WildCardMythics":5,"CustomTokens":{"BonusPackProgress":1,"BattlePass_BRO_Orb":1,"Token_JumpIn":5,"BattlePass_WOE_Orb":1,"BattlePass_MKM_Orb":1},"Boosters":[{"CollationId":100026,"SetCode":"VOW","Count":42},{"CollationId":400026,"SetCode":"Y22MID","Count":3},{"CollationId":100024,"SetCode":"AFR","Count":2},{"CollationId":100027,"SetCode":"NEO","Count":21},{"CollationId":100025,"SetCode":"MID","Count":2},{"CollationId":100029,"SetCode":"HBG","Count":15},{"CollationId":100030,"SetCode":"DMU","Count":7},{"CollationId":100031,"SetCode":"BRO","Count":3},{"CollationId":400031,"SetCode":"Y23BRO","Count":6},{"CollationId":100032,"SetCode":"ONE","Count":4},{"CollationId":400032,"SetCode":"Y23ONE","Count":3},{"CollationId":100033,"SetCode":"SIR","Count":4},{"CollationId":100037,"SetCode":"MOM","Count":4},{"CollationId":100040,"SetCode":"WOE","Count":6},{"CollationId":100039,"SetCode":"LTR","Count":3},{"CollationId":100038,"SetCode":"MAT","Count":3},{"CollationId":400040,"SetCode":"Y24WOE","Count":3},{"CollationId":100041,"SetCode":"LCI","Count":7},{"CollationId":100042,"SetCode":"KTK","Count":3},{"CollationId":400041,"SetCode":"Y24LCI","Count":3},{"CollationId":100043,"SetCode":"MKM","Count":13},{"CollationId":100044,"SetCode":"OTJ","Count":3},{"CollationId":400043,"SetCode":"Y24MKM","Count":3}],"Vouchers":{},"Cosmetics":{"ArtStyles":[{"Type":"ArtStyle","Id":"404952.DA","ArtId":404952,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"409037.DA","ArtId":409037,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"127296.DA","ArtId":127296,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"407656.DA","ArtId":407656,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"402637.DA","ArtId":402637,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"404505.DA","ArtId":404505,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416691.SH","ArtId":416691,"Variant":"SH","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417846.JP","ArtId":417846,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421263.DA","ArtId":421263,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421270.DA","ArtId":421270,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421273.DA","ArtId":421273,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421180.DA","ArtId":421180,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421282.DA","ArtId":421282,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421308.TOHO","ArtId":421308,"Variant":"TOHO","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421132.DA","ArtId":421132,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422314.DA","ArtId":422314,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"417325.DA","ArtId":417325,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"425840.DA","ArtId":425840,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"409970.STORYBOOK","ArtId":409970,"Variant":"STORYBOOK","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"403040.ARCHITECTURE","ArtId":403040,"Variant":"ARCHITECTURE","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"430483.DA","ArtId":430483,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"438995.DA","ArtId":438995,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"430520.DA","ArtId":430520,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418126.SCHEMATIC","ArtId":418126,"Variant":"SCHEMATIC","ExplicitGrpIds":[]}],"Avatars":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_ChandraNalaar","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_AjaniGoldmane","Type":"Avatar"},{"Id":"Avatar_Basic_GideonJura","Type":"Avatar"},{"Id":"Avatar_Basic_Teferi","Type":"Avatar"},{"Id":"Avatar_Basic_SarkhanVol","Type":"Avatar"},{"Id":"Avatar_Basic_Tezzeret","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_VivienReid","Type":"Avatar"},{"Id":"Avatar_Basic_NissaRevane","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_LilianaVess","Type":"Avatar"},{"Id":"Avatar_Basic_Karn","Type":"Avatar"},{"Id":"Avatar_Basic_JayaBallard","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_JaceBeleren","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Elspeth_MOM","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Ashiok_WAR","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Kaito_NEO","Type":"Avatar"}],"Pets":[],"Sleeves":[{"Id":"CardBack_ZNR_402686","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_EmbossedDefaultArena","Type":"Sleeve"},{"Id":"CardBack_ZNR_417011","Type":"Sleeve"},{"Id":"CardBack_M21_413716","Type":"Sleeve"},{"AcquisitionFlags":"Event","Id":"CardBack_IKO_VivienMonstersAdvocate","Type":"Sleeve"},{"Id":"CardBack_DMU_439347","Type":"Sleeve"}],"Emotes":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Hello","Type":"Emote","Category":"Greeting","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Nice_Thanks","Type":"Emote","FlipType":"Reply","Category":"Kudos","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Thinking_YourGo","Type":"Emote","FlipType":"Priority","Category":"Priority","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Oops_Sorry","Type":"Emote","FlipType":"Reply","Category":"Accident","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_GoodGame","Type":"Emote","Category":"GoodGame","Treatment":""},{"Id":"Sticker_MID_Teferi","Type":"Emote","Page":"Sticker","Category":"MID_Stickers","Treatment":"Sticker_MID_Teferi"},{"Id":"Sticker_Halloween23_AngryRoll","Type":"Emote","Page":"Sticker","Category":"Halloween23_Stickers","Treatment":"Sticker_Halloween23_AngryRoll"}]}}}'
     ),
-    ("P1P9 - Pack",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="OTJ",
-                 current_event="QuickDraft",
-                 current_pack=1,
-                 current_pick=9,
-                 picks=["90428"],
-                 pack=["90627","90376","90595","90489","90401","90480"],
-                 card_pool=["90428"],
-                 missing=["90711","90504","90449","90527","90365","90426","90439","90428"]),
-    r'{"CurrentModule":"BotDraft","Payload":"{\"Result\":\"Success\",\"EventName\":\"QuickDraft_OTJ_20240426\",\"DraftStatus\":\"PickNext\",\"PackNumber\":0,\"PickNumber\":8,\"DraftPack\":[\"90627\",\"90376\",\"90595\",\"90489\",\"90401\",\"90480\"],\"PackStyles\":[],\"PickedCards\":[\"90428\",\"90360\",\"90529\",\"90528\",\"90362\",\"90520\",\"90362\",\"90501\"],\"PickedStyles\":[]}","DTO_InventoryInfo":{"SeqId":12,"Changes":[],"Gems":4620,"Gold":1525,"TotalVaultProgress":271,"WildCardCommons":13,"WildCardUnCommons":28,"WildCardRares":7,"WildCardMythics":5,"CustomTokens":{"BonusPackProgress":1,"BattlePass_BRO_Orb":1,"Token_JumpIn":5,"BattlePass_WOE_Orb":1,"BattlePass_MKM_Orb":1},"Boosters":[{"CollationId":100026,"SetCode":"VOW","Count":42},{"CollationId":400026,"SetCode":"Y22MID","Count":3},{"CollationId":100024,"SetCode":"AFR","Count":2},{"CollationId":100027,"SetCode":"NEO","Count":21},{"CollationId":100025,"SetCode":"MID","Count":2},{"CollationId":100029,"SetCode":"HBG","Count":15},{"CollationId":100030,"SetCode":"DMU","Count":7},{"CollationId":100031,"SetCode":"BRO","Count":3},{"CollationId":400031,"SetCode":"Y23BRO","Count":6},{"CollationId":100032,"SetCode":"ONE","Count":4},{"CollationId":400032,"SetCode":"Y23ONE","Count":3},{"CollationId":100033,"SetCode":"SIR","Count":4},{"CollationId":100037,"SetCode":"MOM","Count":4},{"CollationId":100040,"SetCode":"WOE","Count":6},{"CollationId":100039,"SetCode":"LTR","Count":3},{"CollationId":100038,"SetCode":"MAT","Count":3},{"CollationId":400040,"SetCode":"Y24WOE","Count":3},{"CollationId":100041,"SetCode":"LCI","Count":7},{"CollationId":100042,"SetCode":"KTK","Count":3},{"CollationId":400041,"SetCode":"Y24LCI","Count":3},{"CollationId":100043,"SetCode":"MKM","Count":13},{"CollationId":100044,"SetCode":"OTJ","Count":3},{"CollationId":400043,"SetCode":"Y24MKM","Count":3}],"Vouchers":{},"Cosmetics":{"ArtStyles":[{"Type":"ArtStyle","Id":"404952.DA","ArtId":404952,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"409037.DA","ArtId":409037,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"127296.DA","ArtId":127296,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"407656.DA","ArtId":407656,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"402637.DA","ArtId":402637,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"404505.DA","ArtId":404505,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416691.SH","ArtId":416691,"Variant":"SH","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417846.JP","ArtId":417846,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421263.DA","ArtId":421263,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421270.DA","ArtId":421270,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421273.DA","ArtId":421273,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421180.DA","ArtId":421180,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421282.DA","ArtId":421282,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421308.TOHO","ArtId":421308,"Variant":"TOHO","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421132.DA","ArtId":421132,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422314.DA","ArtId":422314,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"417325.DA","ArtId":417325,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"425840.DA","ArtId":425840,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"409970.STORYBOOK","ArtId":409970,"Variant":"STORYBOOK","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"403040.ARCHITECTURE","ArtId":403040,"Variant":"ARCHITECTURE","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"430483.DA","ArtId":430483,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"438995.DA","ArtId":438995,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"430520.DA","ArtId":430520,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418126.SCHEMATIC","ArtId":418126,"Variant":"SCHEMATIC","ExplicitGrpIds":[]}],"Avatars":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_ChandraNalaar","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_AjaniGoldmane","Type":"Avatar"},{"Id":"Avatar_Basic_GideonJura","Type":"Avatar"},{"Id":"Avatar_Basic_Teferi","Type":"Avatar"},{"Id":"Avatar_Basic_SarkhanVol","Type":"Avatar"},{"Id":"Avatar_Basic_Tezzeret","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_VivienReid","Type":"Avatar"},{"Id":"Avatar_Basic_NissaRevane","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_LilianaVess","Type":"Avatar"},{"Id":"Avatar_Basic_Karn","Type":"Avatar"},{"Id":"Avatar_Basic_JayaBallard","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_JaceBeleren","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Elspeth_MOM","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Ashiok_WAR","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Kaito_NEO","Type":"Avatar"}],"Pets":[],"Sleeves":[{"Id":"CardBack_ZNR_402686","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_EmbossedDefaultArena","Type":"Sleeve"},{"Id":"CardBack_ZNR_417011","Type":"Sleeve"},{"Id":"CardBack_M21_413716","Type":"Sleeve"},{"AcquisitionFlags":"Event","Id":"CardBack_IKO_VivienMonstersAdvocate","Type":"Sleeve"},{"Id":"CardBack_DMU_439347","Type":"Sleeve"}],"Emotes":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Hello","Type":"Emote","Category":"Greeting","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Nice_Thanks","Type":"Emote","FlipType":"Reply","Category":"Kudos","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Thinking_YourGo","Type":"Emote","FlipType":"Priority","Category":"Priority","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Oops_Sorry","Type":"Emote","FlipType":"Reply","Category":"Accident","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_GoodGame","Type":"Emote","Category":"GoodGame","Treatment":""},{"Id":"Sticker_MID_Teferi","Type":"Emote","Page":"Sticker","Category":"MID_Stickers","Treatment":"Sticker_MID_Teferi"},{"Id":"Sticker_Halloween23_AngryRoll","Type":"Emote","Page":"Sticker","Category":"Halloween23_Stickers","Treatment":"Sticker_Halloween23_AngryRoll"}]}}}'
+    (
+        "P1P9 - Pack",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="OTJ",
+            current_event="QuickDraft",
+            current_pack=1,
+            current_pick=9,
+            picks=["90428"],
+            pack=["90627","90376","90595","90489","90401","90480"],
+            card_pool=["90428"],
+            missing=["90711","90504","90449","90527","90365","90426","90439","90428"]
+        ),
+        r'{"CurrentModule":"BotDraft","Payload":"{\"Result\":\"Success\",\"EventName\":\"QuickDraft_OTJ_20240426\",\"DraftStatus\":\"PickNext\",\"PackNumber\":0,\"PickNumber\":8,\"DraftPack\":[\"90627\",\"90376\",\"90595\",\"90489\",\"90401\",\"90480\"],\"PackStyles\":[],\"PickedCards\":[\"90428\",\"90360\",\"90529\",\"90528\",\"90362\",\"90520\",\"90362\",\"90501\"],\"PickedStyles\":[]}","DTO_InventoryInfo":{"SeqId":12,"Changes":[],"Gems":4620,"Gold":1525,"TotalVaultProgress":271,"WildCardCommons":13,"WildCardUnCommons":28,"WildCardRares":7,"WildCardMythics":5,"CustomTokens":{"BonusPackProgress":1,"BattlePass_BRO_Orb":1,"Token_JumpIn":5,"BattlePass_WOE_Orb":1,"BattlePass_MKM_Orb":1},"Boosters":[{"CollationId":100026,"SetCode":"VOW","Count":42},{"CollationId":400026,"SetCode":"Y22MID","Count":3},{"CollationId":100024,"SetCode":"AFR","Count":2},{"CollationId":100027,"SetCode":"NEO","Count":21},{"CollationId":100025,"SetCode":"MID","Count":2},{"CollationId":100029,"SetCode":"HBG","Count":15},{"CollationId":100030,"SetCode":"DMU","Count":7},{"CollationId":100031,"SetCode":"BRO","Count":3},{"CollationId":400031,"SetCode":"Y23BRO","Count":6},{"CollationId":100032,"SetCode":"ONE","Count":4},{"CollationId":400032,"SetCode":"Y23ONE","Count":3},{"CollationId":100033,"SetCode":"SIR","Count":4},{"CollationId":100037,"SetCode":"MOM","Count":4},{"CollationId":100040,"SetCode":"WOE","Count":6},{"CollationId":100039,"SetCode":"LTR","Count":3},{"CollationId":100038,"SetCode":"MAT","Count":3},{"CollationId":400040,"SetCode":"Y24WOE","Count":3},{"CollationId":100041,"SetCode":"LCI","Count":7},{"CollationId":100042,"SetCode":"KTK","Count":3},{"CollationId":400041,"SetCode":"Y24LCI","Count":3},{"CollationId":100043,"SetCode":"MKM","Count":13},{"CollationId":100044,"SetCode":"OTJ","Count":3},{"CollationId":400043,"SetCode":"Y24MKM","Count":3}],"Vouchers":{},"Cosmetics":{"ArtStyles":[{"Type":"ArtStyle","Id":"404952.DA","ArtId":404952,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"409037.DA","ArtId":409037,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"127296.DA","ArtId":127296,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"407656.DA","ArtId":407656,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"402637.DA","ArtId":402637,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"404505.DA","ArtId":404505,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416691.SH","ArtId":416691,"Variant":"SH","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417846.JP","ArtId":417846,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421263.DA","ArtId":421263,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421270.DA","ArtId":421270,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421273.DA","ArtId":421273,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421180.DA","ArtId":421180,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421282.DA","ArtId":421282,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421308.TOHO","ArtId":421308,"Variant":"TOHO","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421132.DA","ArtId":421132,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422314.DA","ArtId":422314,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"417325.DA","ArtId":417325,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"425840.DA","ArtId":425840,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"409970.STORYBOOK","ArtId":409970,"Variant":"STORYBOOK","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"403040.ARCHITECTURE","ArtId":403040,"Variant":"ARCHITECTURE","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"430483.DA","ArtId":430483,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"438995.DA","ArtId":438995,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"430520.DA","ArtId":430520,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418126.SCHEMATIC","ArtId":418126,"Variant":"SCHEMATIC","ExplicitGrpIds":[]}],"Avatars":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_ChandraNalaar","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_AjaniGoldmane","Type":"Avatar"},{"Id":"Avatar_Basic_GideonJura","Type":"Avatar"},{"Id":"Avatar_Basic_Teferi","Type":"Avatar"},{"Id":"Avatar_Basic_SarkhanVol","Type":"Avatar"},{"Id":"Avatar_Basic_Tezzeret","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_VivienReid","Type":"Avatar"},{"Id":"Avatar_Basic_NissaRevane","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_LilianaVess","Type":"Avatar"},{"Id":"Avatar_Basic_Karn","Type":"Avatar"},{"Id":"Avatar_Basic_JayaBallard","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_JaceBeleren","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Elspeth_MOM","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Ashiok_WAR","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Kaito_NEO","Type":"Avatar"}],"Pets":[],"Sleeves":[{"Id":"CardBack_ZNR_402686","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_EmbossedDefaultArena","Type":"Sleeve"},{"Id":"CardBack_ZNR_417011","Type":"Sleeve"},{"Id":"CardBack_M21_413716","Type":"Sleeve"},{"AcquisitionFlags":"Event","Id":"CardBack_IKO_VivienMonstersAdvocate","Type":"Sleeve"},{"Id":"CardBack_DMU_439347","Type":"Sleeve"}],"Emotes":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Hello","Type":"Emote","Category":"Greeting","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Nice_Thanks","Type":"Emote","FlipType":"Reply","Category":"Kudos","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Thinking_YourGo","Type":"Emote","FlipType":"Priority","Category":"Priority","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Oops_Sorry","Type":"Emote","FlipType":"Reply","Category":"Accident","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_GoodGame","Type":"Emote","Category":"GoodGame","Treatment":""},{"Id":"Sticker_MID_Teferi","Type":"Emote","Page":"Sticker","Category":"MID_Stickers","Treatment":"Sticker_MID_Teferi"},{"Id":"Sticker_Halloween23_AngryRoll","Type":"Emote","Page":"Sticker","Category":"Halloween23_Stickers","Treatment":"Sticker_Halloween23_AngryRoll"}]}}}'
     ),
-    ("P3P14 - Pack",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="OTJ",
-                 current_event="QuickDraft",
-                 current_pack=3,
-                 current_pick=14,
-                 picks=[],
-                 pack=["90440"],
-                 card_pool=["90428"],
-                 missing=[]),
-    r'{"CurrentModule":"BotDraft","Payload":"{\"Result\":\"Success\",\"EventName\":\"QuickDraft_OTJ_20240426\",\"DraftStatus\":\"PickNext\",\"PackNumber\":2,\"PickNumber\":13,\"DraftPack\":[\"90440\"],\"PackStyles\":[],\"PickedCards\":[\"90376\",\"90428\",\"90600\",\"90360\",\"90595\",\"90529\",\"90595\",\"90528\",\"90481\",\"90362\",\"90419\",\"90520\",\"90362\",\"90501\",\"90379\",\"90500\",\"90380\",\"90520\",\"90632\",\"90379\",\"90506\",\"90593\",\"90514\",\"90353\",\"90726\",\"90423\",\"90384\",\"90530\",\"90378\",\"90567\",\"90376\",\"90504\",\"90502\",\"90432\",\"90507\",\"90382\",\"90414\",\"90506\",\"90382\",\"90507\",\"90507\"],\"PickedStyles\":[]}","DTO_InventoryInfo":{"SeqId":45,"Changes":[],"Gems":4620,"Gold":1525,"TotalVaultProgress":271,"WildCardCommons":13,"WildCardUnCommons":28,"WildCardRares":7,"WildCardMythics":5,"CustomTokens":{"BonusPackProgress":1,"BattlePass_BRO_Orb":1,"Token_JumpIn":5,"BattlePass_WOE_Orb":1,"BattlePass_MKM_Orb":1},"Boosters":[{"CollationId":100026,"SetCode":"VOW","Count":42},{"CollationId":400026,"SetCode":"Y22MID","Count":3},{"CollationId":100024,"SetCode":"AFR","Count":2},{"CollationId":100027,"SetCode":"NEO","Count":21},{"CollationId":100025,"SetCode":"MID","Count":2},{"CollationId":100029,"SetCode":"HBG","Count":15},{"CollationId":100030,"SetCode":"DMU","Count":7},{"CollationId":100031,"SetCode":"BRO","Count":3},{"CollationId":400031,"SetCode":"Y23BRO","Count":6},{"CollationId":100032,"SetCode":"ONE","Count":4},{"CollationId":400032,"SetCode":"Y23ONE","Count":3},{"CollationId":100033,"SetCode":"SIR","Count":4},{"CollationId":100037,"SetCode":"MOM","Count":4},{"CollationId":100040,"SetCode":"WOE","Count":6},{"CollationId":100039,"SetCode":"LTR","Count":3},{"CollationId":100038,"SetCode":"MAT","Count":3},{"CollationId":400040,"SetCode":"Y24WOE","Count":3},{"CollationId":100041,"SetCode":"LCI","Count":7},{"CollationId":100042,"SetCode":"KTK","Count":3},{"CollationId":400041,"SetCode":"Y24LCI","Count":3},{"CollationId":100043,"SetCode":"MKM","Count":13},{"CollationId":100044,"SetCode":"OTJ","Count":3},{"CollationId":400043,"SetCode":"Y24MKM","Count":3}],"Vouchers":{},"Cosmetics":{"ArtStyles":[{"Type":"ArtStyle","Id":"404952.DA","ArtId":404952,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"409037.DA","ArtId":409037,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"127296.DA","ArtId":127296,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"407656.DA","ArtId":407656,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"402637.DA","ArtId":402637,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"404505.DA","ArtId":404505,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416691.SH","ArtId":416691,"Variant":"SH","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417846.JP","ArtId":417846,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421263.DA","ArtId":421263,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421270.DA","ArtId":421270,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421273.DA","ArtId":421273,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421180.DA","ArtId":421180,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421282.DA","ArtId":421282,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421308.TOHO","ArtId":421308,"Variant":"TOHO","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421132.DA","ArtId":421132,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422314.DA","ArtId":422314,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"417325.DA","ArtId":417325,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"425840.DA","ArtId":425840,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"409970.STORYBOOK","ArtId":409970,"Variant":"STORYBOOK","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"403040.ARCHITECTURE","ArtId":403040,"Variant":"ARCHITECTURE","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"430483.DA","ArtId":430483,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"438995.DA","ArtId":438995,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"430520.DA","ArtId":430520,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418126.SCHEMATIC","ArtId":418126,"Variant":"SCHEMATIC","ExplicitGrpIds":[]}],"Avatars":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_ChandraNalaar","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_AjaniGoldmane","Type":"Avatar"},{"Id":"Avatar_Basic_GideonJura","Type":"Avatar"},{"Id":"Avatar_Basic_Teferi","Type":"Avatar"},{"Id":"Avatar_Basic_SarkhanVol","Type":"Avatar"},{"Id":"Avatar_Basic_Tezzeret","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_VivienReid","Type":"Avatar"},{"Id":"Avatar_Basic_NissaRevane","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_LilianaVess","Type":"Avatar"},{"Id":"Avatar_Basic_Karn","Type":"Avatar"},{"Id":"Avatar_Basic_JayaBallard","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_JaceBeleren","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Elspeth_MOM","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Ashiok_WAR","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Kaito_NEO","Type":"Avatar"}],"Pets":[],"Sleeves":[{"Id":"CardBack_ZNR_402686","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_EmbossedDefaultArena","Type":"Sleeve"},{"Id":"CardBack_ZNR_417011","Type":"Sleeve"},{"Id":"CardBack_M21_413716","Type":"Sleeve"},{"AcquisitionFlags":"Event","Id":"CardBack_IKO_VivienMonstersAdvocate","Type":"Sleeve"},{"Id":"CardBack_DMU_439347","Type":"Sleeve"}],"Emotes":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Hello","Type":"Emote","Category":"Greeting","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Nice_Thanks","Type":"Emote","FlipType":"Reply","Category":"Kudos","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Thinking_YourGo","Type":"Emote","FlipType":"Priority","Category":"Priority","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Oops_Sorry","Type":"Emote","FlipType":"Reply","Category":"Accident","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_GoodGame","Type":"Emote","Category":"GoodGame","Treatment":""},{"Id":"Sticker_MID_Teferi","Type":"Emote","Page":"Sticker","Category":"MID_Stickers","Treatment":"Sticker_MID_Teferi"},{"Id":"Sticker_Halloween23_AngryRoll","Type":"Emote","Page":"Sticker","Category":"Halloween23_Stickers","Treatment":"Sticker_Halloween23_AngryRoll"}]}}}'
+    (
+        "P3P14 - Pack",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="OTJ",
+            current_event="QuickDraft",
+            current_pack=3,
+            current_pick=14,
+            picks=[],
+            pack=["90440"],
+            card_pool=["90428"],
+            missing=[]
+        ),
+        r'{"CurrentModule":"BotDraft","Payload":"{\"Result\":\"Success\",\"EventName\":\"QuickDraft_OTJ_20240426\",\"DraftStatus\":\"PickNext\",\"PackNumber\":2,\"PickNumber\":13,\"DraftPack\":[\"90440\"],\"PackStyles\":[],\"PickedCards\":[\"90376\",\"90428\",\"90600\",\"90360\",\"90595\",\"90529\",\"90595\",\"90528\",\"90481\",\"90362\",\"90419\",\"90520\",\"90362\",\"90501\",\"90379\",\"90500\",\"90380\",\"90520\",\"90632\",\"90379\",\"90506\",\"90593\",\"90514\",\"90353\",\"90726\",\"90423\",\"90384\",\"90530\",\"90378\",\"90567\",\"90376\",\"90504\",\"90502\",\"90432\",\"90507\",\"90382\",\"90414\",\"90506\",\"90382\",\"90507\",\"90507\"],\"PickedStyles\":[]}","DTO_InventoryInfo":{"SeqId":45,"Changes":[],"Gems":4620,"Gold":1525,"TotalVaultProgress":271,"WildCardCommons":13,"WildCardUnCommons":28,"WildCardRares":7,"WildCardMythics":5,"CustomTokens":{"BonusPackProgress":1,"BattlePass_BRO_Orb":1,"Token_JumpIn":5,"BattlePass_WOE_Orb":1,"BattlePass_MKM_Orb":1},"Boosters":[{"CollationId":100026,"SetCode":"VOW","Count":42},{"CollationId":400026,"SetCode":"Y22MID","Count":3},{"CollationId":100024,"SetCode":"AFR","Count":2},{"CollationId":100027,"SetCode":"NEO","Count":21},{"CollationId":100025,"SetCode":"MID","Count":2},{"CollationId":100029,"SetCode":"HBG","Count":15},{"CollationId":100030,"SetCode":"DMU","Count":7},{"CollationId":100031,"SetCode":"BRO","Count":3},{"CollationId":400031,"SetCode":"Y23BRO","Count":6},{"CollationId":100032,"SetCode":"ONE","Count":4},{"CollationId":400032,"SetCode":"Y23ONE","Count":3},{"CollationId":100033,"SetCode":"SIR","Count":4},{"CollationId":100037,"SetCode":"MOM","Count":4},{"CollationId":100040,"SetCode":"WOE","Count":6},{"CollationId":100039,"SetCode":"LTR","Count":3},{"CollationId":100038,"SetCode":"MAT","Count":3},{"CollationId":400040,"SetCode":"Y24WOE","Count":3},{"CollationId":100041,"SetCode":"LCI","Count":7},{"CollationId":100042,"SetCode":"KTK","Count":3},{"CollationId":400041,"SetCode":"Y24LCI","Count":3},{"CollationId":100043,"SetCode":"MKM","Count":13},{"CollationId":100044,"SetCode":"OTJ","Count":3},{"CollationId":400043,"SetCode":"Y24MKM","Count":3}],"Vouchers":{},"Cosmetics":{"ArtStyles":[{"Type":"ArtStyle","Id":"404952.DA","ArtId":404952,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"409037.DA","ArtId":409037,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"127296.DA","ArtId":127296,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"407656.DA","ArtId":407656,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"402637.DA","ArtId":402637,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"404505.DA","ArtId":404505,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416691.SH","ArtId":416691,"Variant":"SH","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417846.JP","ArtId":417846,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421263.DA","ArtId":421263,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421270.DA","ArtId":421270,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421273.DA","ArtId":421273,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421180.DA","ArtId":421180,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421282.DA","ArtId":421282,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421308.TOHO","ArtId":421308,"Variant":"TOHO","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421132.DA","ArtId":421132,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422314.DA","ArtId":422314,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"417325.DA","ArtId":417325,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"425840.DA","ArtId":425840,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"409970.STORYBOOK","ArtId":409970,"Variant":"STORYBOOK","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"403040.ARCHITECTURE","ArtId":403040,"Variant":"ARCHITECTURE","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"430483.DA","ArtId":430483,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"438995.DA","ArtId":438995,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"430520.DA","ArtId":430520,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418126.SCHEMATIC","ArtId":418126,"Variant":"SCHEMATIC","ExplicitGrpIds":[]}],"Avatars":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_ChandraNalaar","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_AjaniGoldmane","Type":"Avatar"},{"Id":"Avatar_Basic_GideonJura","Type":"Avatar"},{"Id":"Avatar_Basic_Teferi","Type":"Avatar"},{"Id":"Avatar_Basic_SarkhanVol","Type":"Avatar"},{"Id":"Avatar_Basic_Tezzeret","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_VivienReid","Type":"Avatar"},{"Id":"Avatar_Basic_NissaRevane","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_LilianaVess","Type":"Avatar"},{"Id":"Avatar_Basic_Karn","Type":"Avatar"},{"Id":"Avatar_Basic_JayaBallard","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_JaceBeleren","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Elspeth_MOM","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Ashiok_WAR","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Kaito_NEO","Type":"Avatar"}],"Pets":[],"Sleeves":[{"Id":"CardBack_ZNR_402686","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_EmbossedDefaultArena","Type":"Sleeve"},{"Id":"CardBack_ZNR_417011","Type":"Sleeve"},{"Id":"CardBack_M21_413716","Type":"Sleeve"},{"AcquisitionFlags":"Event","Id":"CardBack_IKO_VivienMonstersAdvocate","Type":"Sleeve"},{"Id":"CardBack_DMU_439347","Type":"Sleeve"}],"Emotes":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Hello","Type":"Emote","Category":"Greeting","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Nice_Thanks","Type":"Emote","FlipType":"Reply","Category":"Kudos","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Thinking_YourGo","Type":"Emote","FlipType":"Priority","Category":"Priority","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Oops_Sorry","Type":"Emote","FlipType":"Reply","Category":"Accident","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_GoodGame","Type":"Emote","Category":"GoodGame","Treatment":""},{"Id":"Sticker_MID_Teferi","Type":"Emote","Page":"Sticker","Category":"MID_Stickers","Treatment":"Sticker_MID_Teferi"},{"Id":"Sticker_Halloween23_AngryRoll","Type":"Emote","Page":"Sticker","Category":"Halloween23_Stickers","Treatment":"Sticker_Halloween23_AngryRoll"}]}}}'
     )
 ]
 
 # Quick draft log entries collected from Player.log after 2024-5-7 Arena update
 DMU_QUICK_DRAFT_ENTRIES_2024_5_7 = [
-    ("Event Start",
-    EventResults(new_event=True,
-                 data_update=False,
-                 current_set="DMU",
-                 current_event="QuickDraft",
-                 current_pack=0,
-                 current_pick=0,
-                 picks=[],
-                 pack=[],
-                 card_pool=[],
-                 missing=[]),
-    r'[UnityCrossThreadLogger]==> BotDraft_DraftStatus {"id":"530a212c-0358-4ee0-bac9-35bf33918d11","request":"{\"EventName\":\"QuickDraft_DMU_20240507\"}"}'
+    (
+        "Event Start",
+        EventResults(
+            new_event=True,
+            data_update=False,
+            current_set="DMU",
+            current_event="QuickDraft",
+            current_pack=0,
+            current_pick=0,
+            picks=[],
+            pack=[],
+            card_pool=[],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]==> BotDraft_DraftStatus {"id":"530a212c-0358-4ee0-bac9-35bf33918d11","request":"{\"EventName\":\"QuickDraft_DMU_20240507\"}"}'
     ),
-    ("P1P1 - Pack",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="DMU",
-                 current_event="QuickDraft",
-                 current_pack=1,
-                 current_pick=1,
-                 picks=[],
-                 pack=["82309","82207","82083","82165","82196","82129","82170","82146","82120","82059","82160","82168","82091","82256"],
-                 card_pool=[],
-                 missing=[]),
-    r'{"CurrentModule":"BotDraft","Payload":"{\"Result\":\"Success\",\"EventName\":\"QuickDraft_DMU_20240507\",\"DraftStatus\":\"PickNext\",\"PackNumber\":0,\"PickNumber\":0,\"DraftPack\":[\"82309\",\"82207\",\"82083\",\"82165\",\"82196\",\"82129\",\"82170\",\"82146\",\"82120\",\"82059\",\"82160\",\"82168\",\"82091\",\"82256\"],\"PackStyles\":[],\"PickedCards\":[],\"PickedStyles\":[]}"}'
+    (
+        "P1P1 - Pack",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="DMU",
+            current_event="QuickDraft",
+            current_pack=1,
+            current_pick=1,
+            picks=[],
+            pack=["82309","82207","82083","82165","82196","82129","82170","82146","82120","82059","82160","82168","82091","82256"],
+            card_pool=[],
+            missing=[]
+        ),
+        r'{"CurrentModule":"BotDraft","Payload":"{\"Result\":\"Success\",\"EventName\":\"QuickDraft_DMU_20240507\",\"DraftStatus\":\"PickNext\",\"PackNumber\":0,\"PickNumber\":0,\"DraftPack\":[\"82309\",\"82207\",\"82083\",\"82165\",\"82196\",\"82129\",\"82170\",\"82146\",\"82120\",\"82059\",\"82160\",\"82168\",\"82091\",\"82256\"],\"PackStyles\":[],\"PickedCards\":[],\"PickedStyles\":[]}"}'
     ),
-    ("P1P1 - Pick",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="DMU",
-                 current_event="QuickDraft",
-                 current_pack=1,
-                 current_pick=1,
-                 picks=["82091"],
-                 pack=["82309","82207","82083","82165","82196","82129","82170","82146","82120","82059","82160","82168","82091","82256"],
-                 card_pool=["82091"],
-                 missing=[]),
-    r'[UnityCrossThreadLogger]==> BotDraftDraftPick {"id":"a4bc9a1c-8b5a-4939-85f8-d2eb524b5069","request":"{\"EventName\":\"QuickDraft_DMU_20240507\",\"PickInfo\":{\"EventName\":\"QuickDraft_DMU_20240507\",\"CardIds\":[\"82091\"],\"PackNumber\":0,\"PickNumber\":0}}"}'
+    (
+        "P1P1 - Pick",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="DMU",
+            current_event="QuickDraft",
+            current_pack=1,
+            current_pick=1,
+            picks=["82091"],
+            pack=["82309","82207","82083","82165","82196","82129","82170","82146","82120","82059","82160","82168","82091","82256"],
+            card_pool=["82091"],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]==> BotDraft_DraftPick {"id":"a4bc9a1c-8b5a-4939-85f8-d2eb524b5069","request":"{\"EventName\":\"QuickDraft_DMU_20240507\",\"PickInfo\":{\"EventName\":\"QuickDraft_DMU_20240507\",\"CardId\":\"82091\",\"PackNumber\":0,\"PickNumber\":0}}"}'
     ),
-    ("P1P2 - Pack",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="DMU",
-                 current_event="QuickDraft",
-                 current_pack=1,
-                 current_pick=2,
-                 picks=[],
-                 pack=["82200","82129","82179","82062","82299","82209","82228","82074","82153","82281","82096","82140","82245"],
-                 card_pool=["82091"],
-                 missing=[]),
-    r'{"CurrentModule":"BotDraft","Payload":"{\"Result\":\"Success\",\"EventName\":\"QuickDraft_DMU_20240507\",\"DraftStatus\":\"PickNext\",\"PackNumber\":0,\"PickNumber\":1,\"DraftPack\":[\"82200\",\"82129\",\"82179\",\"82062\",\"82299\",\"82209\",\"82228\",\"82074\",\"82153\",\"82281\",\"82096\",\"82140\",\"82245\"],\"PackStyles\":[],\"PickedCards\":[\"82091\"],\"PickedStyles\":[]}","DTO_InventoryInfo":{"SeqId":7,"Changes":[],"Gems":2300,"Gold":4500,"TotalVaultProgress":868,"wcTrackPosition":6,"WildCardCommons":68,"WildCardUnCommons":87,"WildCardRares":28,"WildCardMythics":12,"CustomTokens":{"BattlePass_AFR_Orb":1,"BattlePass_HBG_Orb":1,"BonusPackProgress":1,"BattlePass_MKM_Orb":1,"DraftToken":1},"Boosters":[{"CollationId":100026,"SetCode":"VOW","Count":10},{"CollationId":100024,"SetCode":"AFR","Count":7},{"CollationId":100020,"SetCode":"ZNR","Count":2},{"CollationId":100022,"SetCode":"KHM","Count":2},{"CollationId":100023,"SetCode":"STX","Count":3},{"CollationId":100025,"SetCode":"MID","Count":4},{"CollationId":100027,"SetCode":"NEO","Count":41},{"CollationId":100028,"SetCode":"SNC","Count":3},{"CollationId":400028,"SetCode":"Y22SNC","Count":1},{"CollationId":100029,"SetCode":"HBG","Count":8},{"CollationId":100030,"SetCode":"DMU","Count":1},{"CollationId":100031,"SetCode":"BRO","Count":1},{"CollationId":100032,"SetCode":"ONE","Count":3},{"CollationId":100033,"SetCode":"SIR","Count":3},{"CollationId":100037,"SetCode":"MOM","Count":3},{"CollationId":100039,"SetCode":"LTR","Count":3},{"CollationId":100040,"SetCode":"WOE","Count":3},{"CollationId":400031,"SetCode":"Y23BRO","Count":6},{"CollationId":400032,"SetCode":"Y23ONE","Count":3},{"CollationId":100038,"SetCode":"MAT","Count":3},{"CollationId":400040,"SetCode":"Y24WOE","Count":3},{"CollationId":400041,"SetCode":"Y24LCI","Count":3},{"CollationId":100042,"SetCode":"KTK","Count":3},{"CollationId":100041,"SetCode":"LCI","Count":4},{"CollationId":100043,"SetCode":"MKM","Count":6},{"CollationId":100044,"SetCode":"OTJ","Count":4},{"CollationId":400043,"SetCode":"Y24MKM","Count":3},{"CollationId":400044,"SetCode":"Y24OTJ","Count":3}],"Vouchers":{},"Cosmetics":{"ArtStyles":[{"Type":"ArtStyle","Id":"404952.DA","ArtId":404952,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"409037.DA","ArtId":409037,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"127296.DA","ArtId":127296,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"404505.DA","ArtId":404505,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"402637.DA","ArtId":402637,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"407656.DA","ArtId":407656,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418892.DA","ArtId":418892,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418903.DA","ArtId":418903,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"Event","Type":"ArtStyle","Id":"420249.JP","ArtId":420249,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416627.SH","ArtId":416627,"Variant":"SH","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417880.JP","ArtId":417880,"Variant":"JP","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406523.SG","ArtId":406523,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406664.SG","ArtId":406664,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"409514.SG","ArtId":409514,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406559.SG","ArtId":406559,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406626.SG","ArtId":406626,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"402959.DA","ArtId":402959,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"400332.DA","ArtId":400332,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"404135.DA","ArtId":404135,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"404488.DA","ArtId":404488,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"402057.DA","ArtId":402057,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418809.DA","ArtId":418809,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418895.DA","ArtId":418895,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418859.DA","ArtId":418859,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418963.DA","ArtId":418963,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418925.DA","ArtId":418925,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418777.DA","ArtId":418777,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418962.DA","ArtId":418962,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418781.DA","ArtId":418781,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418812.DA","ArtId":418812,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416383.DA","ArtId":416383,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416356.DA","ArtId":416356,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418912.DA","ArtId":418912,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418917.DA","ArtId":418917,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418785.DA","ArtId":418785,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418790.DA","ArtId":418790,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418988.DA","ArtId":418988,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418798.DA","ArtId":418798,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419549.DA","ArtId":419549,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419568.DA","ArtId":419568,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"418867.DA","ArtId":418867,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419407.DA","ArtId":419407,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419576.DA","ArtId":419576,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422879.DA","ArtId":422879,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419437.DA","ArtId":419437,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419501.DA","ArtId":419501,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419546.DA","ArtId":419546,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419693.DA","ArtId":419693,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"415977.DA","ArtId":415977,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419600.DA","ArtId":419600,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419682.DA","ArtId":419682,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419495.DA","ArtId":419495,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419551.DA","ArtId":419551,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419683.DA","ArtId":419683,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419694.DA","ArtId":419694,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419488.DA","ArtId":419488,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419685.DA","ArtId":419685,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419452.DA","ArtId":419452,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419643.DA","ArtId":419643,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419687.DA","ArtId":419687,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419567.DA","ArtId":419567,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419720.DA","ArtId":419720,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"415990.DA","ArtId":415990,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419665.DA","ArtId":419665,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419664.DA","ArtId":419664,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419722.DA","ArtId":419722,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419672.DA","ArtId":419672,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419676.DA","ArtId":419676,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419601.DA","ArtId":419601,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419620.DA","ArtId":419620,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419617.DA","ArtId":419617,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419721.DA","ArtId":419721,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"424152.DA","ArtId":424152,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419628.DA","ArtId":419628,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419492.DA","ArtId":419492,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419514.DA","ArtId":419514,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419515.DA","ArtId":419515,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419436.DA","ArtId":419436,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419719.DA","ArtId":419719,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"Event","Type":"ArtStyle","Id":"417888.JP","ArtId":417888,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419536.DA","ArtId":419536,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419528.DA","ArtId":419528,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419527.DA","ArtId":419527,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419593.DA","ArtId":419593,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419446.DA","ArtId":419446,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"415986.DA","ArtId":415986,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419468.DA","ArtId":419468,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419602.DA","ArtId":419602,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419466.DA","ArtId":419466,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419690.DA","ArtId":419690,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419692.DA","ArtId":419692,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419718.DA","ArtId":419718,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419651.DA","ArtId":419651,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419473.DA","ArtId":419473,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419467.DA","ArtId":419467,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419630.DA","ArtId":419630,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419688.DA","ArtId":419688,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419476.DA","ArtId":419476,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421125.DA","ArtId":421125,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417889.JP","ArtId":417889,"Variant":"JP","ExplicitGrpIds":[]},{"AcquisitionFlags":"Event","Type":"ArtStyle","Id":"417868.JP","ArtId":417868,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417340.DA","ArtId":417340,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421130.DA","ArtId":421130,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419511.DA","ArtId":419511,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421133.DA","ArtId":421133,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417319.DA","ArtId":417319,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421180.DA","ArtId":421180,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421284.DA","ArtId":421284,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421132.DA","ArtId":421132,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421237.DA","ArtId":421237,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421114.DA","ArtId":421114,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421162.DA","ArtId":421162,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417065.DA","ArtId":417065,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421259.DA","ArtId":421259,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417343.DA","ArtId":417343,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421343.DA","ArtId":421343,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417314.DA","ArtId":417314,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417066.DA","ArtId":417066,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421159.DA","ArtId":421159,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417063.DA","ArtId":417063,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421346.DA","ArtId":421346,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417332.DA","ArtId":417332,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421297.DA","ArtId":421297,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417361.DA","ArtId":417361,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421121.DA","ArtId":421121,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421170.DA","ArtId":421170,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421342.DA","ArtId":421342,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421212.DA","ArtId":421212,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421254.DA","ArtId":421254,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421150.DA","ArtId":421150,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421172.DA","ArtId":421172,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421184.DA","ArtId":421184,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421185.DA","ArtId":421185,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421198.DA","ArtId":421198,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421193.DA","ArtId":421193,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421205.DA","ArtId":421205,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421227.DA","ArtId":421227,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421229.DA","ArtId":421229,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417351.DA","ArtId":417351,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421242.DA","ArtId":421242,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421263.DA","ArtId":421263,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421270.DA","ArtId":421270,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421273.DA","ArtId":421273,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421282.DA","ArtId":421282,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421344.DA","ArtId":421344,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421283.DA","ArtId":421283,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421303.DA","ArtId":421303,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422142.DA","ArtId":422142,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422322.DA","ArtId":422322,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"417325.DA","ArtId":417325,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421142.DA","ArtId":421142,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422152.DA","ArtId":422152,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422167.DA","ArtId":422167,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"422148.DA","ArtId":422148,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"422213.DA","ArtId":422213,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"443063.DA","ArtId":443063,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418126.SCHEMATIC","ArtId":418126,"Variant":"SCHEMATIC","ExplicitGrpIds":[]}],"Avatars":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_ChandraNalaar","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_AjaniGoldmane","Type":"Avatar"},{"Id":"Avatar_Basic_GideonJura","Type":"Avatar"},{"Id":"Avatar_Basic_Teferi","Type":"Avatar"},{"Id":"Avatar_Basic_SarkhanVol","Type":"Avatar"},{"Id":"Avatar_Basic_Tezzeret","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_VivienReid","Type":"Avatar"},{"Id":"Avatar_Basic_NissaRevane","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_LilianaVess","Type":"Avatar"},{"Id":"Avatar_Basic_Karn","Type":"Avatar"},{"Id":"Avatar_Basic_JayaBallard","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_JaceBeleren","Type":"Avatar"},{"Id":"Avatar_Basic_Ellywick_AFR","Type":"Avatar"},{"Id":"Avatar_Basic_Wrenn_MID","Type":"Avatar"},{"AcquisitionFlags":"CodeRedemption","Id":"Avatar_Basic_Sorin_VOW","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Elspeth_MOM","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Ashiok_WAR","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Kaito_NEO","Type":"Avatar"}],"Pets":[{"Type":"Pet","Id":"AFR_Dragon.Skin1","Name":"AFR_Dragon","Variant":"Skin1"},{"Type":"Pet","Id":"AFR_Dragon.Skin2","Name":"AFR_Dragon","Variant":"Skin2"},{"Type":"Pet","Id":"MID_Geist.Skin1","Name":"MID_Geist","Variant":"Skin1"},{"Type":"Pet","Id":"MID_Geist.Skin2","Name":"MID_Geist","Variant":"Skin2"},{"Type":"Pet","Id":"MID_Geist.Skin3","Name":"MID_Geist","Variant":"Skin3"},{"Type":"Pet","Id":"VOW_Bat.Level1","Name":"VOW_Bat","Variant":"Level1"},{"Type":"Pet","Id":"VOW_Bat.Level2","Name":"VOW_Bat","Variant":"Level2"},{"Type":"Pet","Id":"VOW_Bat.Level3","Name":"VOW_Bat","Variant":"Level3"}],"Sleeves":[{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_Basic_Thunderstorm_Bitterblossom","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418002","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418001","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418003","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418004","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418005","Type":"Sleeve"},{"Id":"CardBack_AFR_419749","Type":"Sleeve"},{"Id":"CardBack_AFR_419144","Type":"Sleeve"},{"Id":"CardBack_AFR_419111","Type":"Sleeve"},{"Id":"CardBack_MID_424253","Type":"Sleeve"},{"Id":"CardBack_MID_423524","Type":"Sleeve"},{"Id":"CardBack_ZNR_402686","Type":"Sleeve"},{"Id":"CardBack_MID_422493","Type":"Sleeve"},{"Id":"CardBack_VOW_424637","Type":"Sleeve"},{"Id":"CardBack_VOW_422028","Type":"Sleeve"},{"Id":"CardBack_VOW_422180","Type":"Sleeve"},{"Id":"CardBack_VOW_421278","Type":"Sleeve"},{"Id":"CardBack_VOW_421349","Type":"Sleeve"},{"AcquisitionFlags":"Event, CodeRedemption","Id":"CardBack_DvC_409074","Type":"Sleeve"}],"Emotes":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Hello","Type":"Emote","Category":"Greeting","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Nice_Thanks","Type":"Emote","FlipType":"Reply","Category":"Kudos","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Thinking_YourGo","Type":"Emote","FlipType":"Priority","Category":"Priority","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Oops_Sorry","Type":"Emote","FlipType":"Reply","Category":"Accident","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_GoodGame","Type":"Emote","Category":"GoodGame","Treatment":""}]}}}'
+    (
+        "P1P2 - Pack",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="DMU",
+            current_event="QuickDraft",
+            current_pack=1,
+            current_pick=2,
+            picks=[],
+            pack=["82200","82129","82179","82062","82299","82209","82228","82074","82153","82281","82096","82140","82245"],
+            card_pool=["82091"],
+            missing=[]
+        ),
+        r'{"CurrentModule":"BotDraft","Payload":"{\"Result\":\"Success\",\"EventName\":\"QuickDraft_DMU_20240507\",\"DraftStatus\":\"PickNext\",\"PackNumber\":0,\"PickNumber\":1,\"DraftPack\":[\"82200\",\"82129\",\"82179\",\"82062\",\"82299\",\"82209\",\"82228\",\"82074\",\"82153\",\"82281\",\"82096\",\"82140\",\"82245\"],\"PackStyles\":[],\"PickedCards\":[\"82091\"],\"PickedStyles\":[]}","DTO_InventoryInfo":{"SeqId":7,"Changes":[],"Gems":2300,"Gold":4500,"TotalVaultProgress":868,"wcTrackPosition":6,"WildCardCommons":68,"WildCardUnCommons":87,"WildCardRares":28,"WildCardMythics":12,"CustomTokens":{"BattlePass_AFR_Orb":1,"BattlePass_HBG_Orb":1,"BonusPackProgress":1,"BattlePass_MKM_Orb":1,"DraftToken":1},"Boosters":[{"CollationId":100026,"SetCode":"VOW","Count":10},{"CollationId":100024,"SetCode":"AFR","Count":7},{"CollationId":100020,"SetCode":"ZNR","Count":2},{"CollationId":100022,"SetCode":"KHM","Count":2},{"CollationId":100023,"SetCode":"STX","Count":3},{"CollationId":100025,"SetCode":"MID","Count":4},{"CollationId":100027,"SetCode":"NEO","Count":41},{"CollationId":100028,"SetCode":"SNC","Count":3},{"CollationId":400028,"SetCode":"Y22SNC","Count":1},{"CollationId":100029,"SetCode":"HBG","Count":8},{"CollationId":100030,"SetCode":"DMU","Count":1},{"CollationId":100031,"SetCode":"BRO","Count":1},{"CollationId":100032,"SetCode":"ONE","Count":3},{"CollationId":100033,"SetCode":"SIR","Count":3},{"CollationId":100037,"SetCode":"MOM","Count":3},{"CollationId":100039,"SetCode":"LTR","Count":3},{"CollationId":100040,"SetCode":"WOE","Count":3},{"CollationId":400031,"SetCode":"Y23BRO","Count":6},{"CollationId":400032,"SetCode":"Y23ONE","Count":3},{"CollationId":100038,"SetCode":"MAT","Count":3},{"CollationId":400040,"SetCode":"Y24WOE","Count":3},{"CollationId":400041,"SetCode":"Y24LCI","Count":3},{"CollationId":100042,"SetCode":"KTK","Count":3},{"CollationId":100041,"SetCode":"LCI","Count":4},{"CollationId":100043,"SetCode":"MKM","Count":6},{"CollationId":100044,"SetCode":"OTJ","Count":4},{"CollationId":400043,"SetCode":"Y24MKM","Count":3},{"CollationId":400044,"SetCode":"Y24OTJ","Count":3}],"Vouchers":{},"Cosmetics":{"ArtStyles":[{"Type":"ArtStyle","Id":"404952.DA","ArtId":404952,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"409037.DA","ArtId":409037,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"127296.DA","ArtId":127296,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"404505.DA","ArtId":404505,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"402637.DA","ArtId":402637,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"407656.DA","ArtId":407656,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418892.DA","ArtId":418892,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418903.DA","ArtId":418903,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"Event","Type":"ArtStyle","Id":"420249.JP","ArtId":420249,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416627.SH","ArtId":416627,"Variant":"SH","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417880.JP","ArtId":417880,"Variant":"JP","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406523.SG","ArtId":406523,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406664.SG","ArtId":406664,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"409514.SG","ArtId":409514,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406559.SG","ArtId":406559,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406626.SG","ArtId":406626,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"402959.DA","ArtId":402959,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"400332.DA","ArtId":400332,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"404135.DA","ArtId":404135,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"404488.DA","ArtId":404488,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"402057.DA","ArtId":402057,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418809.DA","ArtId":418809,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418895.DA","ArtId":418895,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418859.DA","ArtId":418859,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418963.DA","ArtId":418963,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418925.DA","ArtId":418925,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418777.DA","ArtId":418777,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418962.DA","ArtId":418962,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418781.DA","ArtId":418781,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418812.DA","ArtId":418812,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416383.DA","ArtId":416383,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416356.DA","ArtId":416356,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418912.DA","ArtId":418912,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418917.DA","ArtId":418917,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418785.DA","ArtId":418785,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418790.DA","ArtId":418790,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418988.DA","ArtId":418988,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418798.DA","ArtId":418798,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419549.DA","ArtId":419549,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419568.DA","ArtId":419568,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"418867.DA","ArtId":418867,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419407.DA","ArtId":419407,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419576.DA","ArtId":419576,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422879.DA","ArtId":422879,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419437.DA","ArtId":419437,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419501.DA","ArtId":419501,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419546.DA","ArtId":419546,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419693.DA","ArtId":419693,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"415977.DA","ArtId":415977,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419600.DA","ArtId":419600,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419682.DA","ArtId":419682,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419495.DA","ArtId":419495,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419551.DA","ArtId":419551,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419683.DA","ArtId":419683,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419694.DA","ArtId":419694,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419488.DA","ArtId":419488,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419685.DA","ArtId":419685,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419452.DA","ArtId":419452,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419643.DA","ArtId":419643,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419687.DA","ArtId":419687,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419567.DA","ArtId":419567,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419720.DA","ArtId":419720,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"415990.DA","ArtId":415990,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419665.DA","ArtId":419665,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419664.DA","ArtId":419664,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419722.DA","ArtId":419722,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419672.DA","ArtId":419672,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419676.DA","ArtId":419676,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419601.DA","ArtId":419601,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419620.DA","ArtId":419620,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419617.DA","ArtId":419617,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419721.DA","ArtId":419721,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"424152.DA","ArtId":424152,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419628.DA","ArtId":419628,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419492.DA","ArtId":419492,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419514.DA","ArtId":419514,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419515.DA","ArtId":419515,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419436.DA","ArtId":419436,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419719.DA","ArtId":419719,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"Event","Type":"ArtStyle","Id":"417888.JP","ArtId":417888,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419536.DA","ArtId":419536,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419528.DA","ArtId":419528,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419527.DA","ArtId":419527,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419593.DA","ArtId":419593,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419446.DA","ArtId":419446,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"415986.DA","ArtId":415986,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419468.DA","ArtId":419468,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419602.DA","ArtId":419602,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419466.DA","ArtId":419466,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419690.DA","ArtId":419690,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419692.DA","ArtId":419692,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419718.DA","ArtId":419718,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419651.DA","ArtId":419651,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419473.DA","ArtId":419473,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419467.DA","ArtId":419467,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419630.DA","ArtId":419630,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419688.DA","ArtId":419688,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419476.DA","ArtId":419476,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421125.DA","ArtId":421125,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417889.JP","ArtId":417889,"Variant":"JP","ExplicitGrpIds":[]},{"AcquisitionFlags":"Event","Type":"ArtStyle","Id":"417868.JP","ArtId":417868,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417340.DA","ArtId":417340,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421130.DA","ArtId":421130,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419511.DA","ArtId":419511,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421133.DA","ArtId":421133,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417319.DA","ArtId":417319,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421180.DA","ArtId":421180,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421284.DA","ArtId":421284,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421132.DA","ArtId":421132,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421237.DA","ArtId":421237,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421114.DA","ArtId":421114,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421162.DA","ArtId":421162,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417065.DA","ArtId":417065,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421259.DA","ArtId":421259,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417343.DA","ArtId":417343,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421343.DA","ArtId":421343,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417314.DA","ArtId":417314,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417066.DA","ArtId":417066,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421159.DA","ArtId":421159,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417063.DA","ArtId":417063,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421346.DA","ArtId":421346,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417332.DA","ArtId":417332,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421297.DA","ArtId":421297,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417361.DA","ArtId":417361,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421121.DA","ArtId":421121,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421170.DA","ArtId":421170,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421342.DA","ArtId":421342,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421212.DA","ArtId":421212,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421254.DA","ArtId":421254,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421150.DA","ArtId":421150,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421172.DA","ArtId":421172,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421184.DA","ArtId":421184,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421185.DA","ArtId":421185,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421198.DA","ArtId":421198,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421193.DA","ArtId":421193,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421205.DA","ArtId":421205,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421227.DA","ArtId":421227,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421229.DA","ArtId":421229,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417351.DA","ArtId":417351,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421242.DA","ArtId":421242,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421263.DA","ArtId":421263,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421270.DA","ArtId":421270,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421273.DA","ArtId":421273,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421282.DA","ArtId":421282,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421344.DA","ArtId":421344,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421283.DA","ArtId":421283,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421303.DA","ArtId":421303,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422142.DA","ArtId":422142,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422322.DA","ArtId":422322,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"417325.DA","ArtId":417325,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421142.DA","ArtId":421142,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422152.DA","ArtId":422152,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422167.DA","ArtId":422167,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"422148.DA","ArtId":422148,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"422213.DA","ArtId":422213,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"443063.DA","ArtId":443063,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418126.SCHEMATIC","ArtId":418126,"Variant":"SCHEMATIC","ExplicitGrpIds":[]}],"Avatars":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_ChandraNalaar","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_AjaniGoldmane","Type":"Avatar"},{"Id":"Avatar_Basic_GideonJura","Type":"Avatar"},{"Id":"Avatar_Basic_Teferi","Type":"Avatar"},{"Id":"Avatar_Basic_SarkhanVol","Type":"Avatar"},{"Id":"Avatar_Basic_Tezzeret","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_VivienReid","Type":"Avatar"},{"Id":"Avatar_Basic_NissaRevane","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_LilianaVess","Type":"Avatar"},{"Id":"Avatar_Basic_Karn","Type":"Avatar"},{"Id":"Avatar_Basic_JayaBallard","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_JaceBeleren","Type":"Avatar"},{"Id":"Avatar_Basic_Ellywick_AFR","Type":"Avatar"},{"Id":"Avatar_Basic_Wrenn_MID","Type":"Avatar"},{"AcquisitionFlags":"CodeRedemption","Id":"Avatar_Basic_Sorin_VOW","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Elspeth_MOM","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Ashiok_WAR","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Kaito_NEO","Type":"Avatar"}],"Pets":[{"Type":"Pet","Id":"AFR_Dragon.Skin1","Name":"AFR_Dragon","Variant":"Skin1"},{"Type":"Pet","Id":"AFR_Dragon.Skin2","Name":"AFR_Dragon","Variant":"Skin2"},{"Type":"Pet","Id":"MID_Geist.Skin1","Name":"MID_Geist","Variant":"Skin1"},{"Type":"Pet","Id":"MID_Geist.Skin2","Name":"MID_Geist","Variant":"Skin2"},{"Type":"Pet","Id":"MID_Geist.Skin3","Name":"MID_Geist","Variant":"Skin3"},{"Type":"Pet","Id":"VOW_Bat.Level1","Name":"VOW_Bat","Variant":"Level1"},{"Type":"Pet","Id":"VOW_Bat.Level2","Name":"VOW_Bat","Variant":"Level2"},{"Type":"Pet","Id":"VOW_Bat.Level3","Name":"VOW_Bat","Variant":"Level3"}],"Sleeves":[{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_Basic_Thunderstorm_Bitterblossom","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418002","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418001","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418003","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418004","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418005","Type":"Sleeve"},{"Id":"CardBack_AFR_419749","Type":"Sleeve"},{"Id":"CardBack_AFR_419144","Type":"Sleeve"},{"Id":"CardBack_AFR_419111","Type":"Sleeve"},{"Id":"CardBack_MID_424253","Type":"Sleeve"},{"Id":"CardBack_MID_423524","Type":"Sleeve"},{"Id":"CardBack_ZNR_402686","Type":"Sleeve"},{"Id":"CardBack_MID_422493","Type":"Sleeve"},{"Id":"CardBack_VOW_424637","Type":"Sleeve"},{"Id":"CardBack_VOW_422028","Type":"Sleeve"},{"Id":"CardBack_VOW_422180","Type":"Sleeve"},{"Id":"CardBack_VOW_421278","Type":"Sleeve"},{"Id":"CardBack_VOW_421349","Type":"Sleeve"},{"AcquisitionFlags":"Event, CodeRedemption","Id":"CardBack_DvC_409074","Type":"Sleeve"}],"Emotes":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Hello","Type":"Emote","Category":"Greeting","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Nice_Thanks","Type":"Emote","FlipType":"Reply","Category":"Kudos","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Thinking_YourGo","Type":"Emote","FlipType":"Priority","Category":"Priority","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Oops_Sorry","Type":"Emote","FlipType":"Reply","Category":"Accident","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_GoodGame","Type":"Emote","Category":"GoodGame","Treatment":""}]}}}'
     ),
-    ("P1P9 - Pack",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="DMU",
-                 current_event="QuickDraft",
-                 current_pack=1,
-                 current_pick=9,
-                 picks=["82091"],
-                 pack=["82083","82196","82129","82170","82059","82160"],
-                 card_pool=["82091"],
-                 missing=["82309","82207","82165","82146","82120","82168","82091","82256"]),
-    r'{"CurrentModule":"BotDraft","Payload":"{\"Result\":\"Success\",\"EventName\":\"QuickDraft_DMU_20240507\",\"DraftStatus\":\"PickNext\",\"PackNumber\":0,\"PickNumber\":8,\"DraftPack\":[\"82083\",\"82196\",\"82129\",\"82170\",\"82059\",\"82160\"],\"PackStyles\":[],\"PickedCards\":[\"82091\",\"82140\",\"82065\",\"82124\",\"82303\",\"82123\",\"82249\",\"82309\"],\"PickedStyles\":[]}","DTO_InventoryInfo":{"SeqId":14,"Changes":[],"Gems":2300,"Gold":4500,"TotalVaultProgress":868,"wcTrackPosition":6,"WildCardCommons":68,"WildCardUnCommons":87,"WildCardRares":28,"WildCardMythics":12,"CustomTokens":{"BattlePass_AFR_Orb":1,"BattlePass_HBG_Orb":1,"BonusPackProgress":1,"BattlePass_MKM_Orb":1,"DraftToken":1},"Boosters":[{"CollationId":100026,"SetCode":"VOW","Count":10},{"CollationId":100024,"SetCode":"AFR","Count":7},{"CollationId":100020,"SetCode":"ZNR","Count":2},{"CollationId":100022,"SetCode":"KHM","Count":2},{"CollationId":100023,"SetCode":"STX","Count":3},{"CollationId":100025,"SetCode":"MID","Count":4},{"CollationId":100027,"SetCode":"NEO","Count":41},{"CollationId":100028,"SetCode":"SNC","Count":3},{"CollationId":400028,"SetCode":"Y22SNC","Count":1},{"CollationId":100029,"SetCode":"HBG","Count":8},{"CollationId":100030,"SetCode":"DMU","Count":1},{"CollationId":100031,"SetCode":"BRO","Count":1},{"CollationId":100032,"SetCode":"ONE","Count":3},{"CollationId":100033,"SetCode":"SIR","Count":3},{"CollationId":100037,"SetCode":"MOM","Count":3},{"CollationId":100039,"SetCode":"LTR","Count":3},{"CollationId":100040,"SetCode":"WOE","Count":3},{"CollationId":400031,"SetCode":"Y23BRO","Count":6},{"CollationId":400032,"SetCode":"Y23ONE","Count":3},{"CollationId":100038,"SetCode":"MAT","Count":3},{"CollationId":400040,"SetCode":"Y24WOE","Count":3},{"CollationId":400041,"SetCode":"Y24LCI","Count":3},{"CollationId":100042,"SetCode":"KTK","Count":3},{"CollationId":100041,"SetCode":"LCI","Count":4},{"CollationId":100043,"SetCode":"MKM","Count":6},{"CollationId":100044,"SetCode":"OTJ","Count":4},{"CollationId":400043,"SetCode":"Y24MKM","Count":3},{"CollationId":400044,"SetCode":"Y24OTJ","Count":3}],"Vouchers":{},"Cosmetics":{"ArtStyles":[{"Type":"ArtStyle","Id":"404952.DA","ArtId":404952,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"409037.DA","ArtId":409037,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"127296.DA","ArtId":127296,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"404505.DA","ArtId":404505,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"402637.DA","ArtId":402637,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"407656.DA","ArtId":407656,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418892.DA","ArtId":418892,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418903.DA","ArtId":418903,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"Event","Type":"ArtStyle","Id":"420249.JP","ArtId":420249,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416627.SH","ArtId":416627,"Variant":"SH","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417880.JP","ArtId":417880,"Variant":"JP","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406523.SG","ArtId":406523,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406664.SG","ArtId":406664,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"409514.SG","ArtId":409514,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406559.SG","ArtId":406559,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406626.SG","ArtId":406626,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"402959.DA","ArtId":402959,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"400332.DA","ArtId":400332,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"404135.DA","ArtId":404135,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"404488.DA","ArtId":404488,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"402057.DA","ArtId":402057,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418809.DA","ArtId":418809,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418895.DA","ArtId":418895,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418859.DA","ArtId":418859,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418963.DA","ArtId":418963,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418925.DA","ArtId":418925,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418777.DA","ArtId":418777,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418962.DA","ArtId":418962,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418781.DA","ArtId":418781,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418812.DA","ArtId":418812,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416383.DA","ArtId":416383,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416356.DA","ArtId":416356,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418912.DA","ArtId":418912,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418917.DA","ArtId":418917,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418785.DA","ArtId":418785,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418790.DA","ArtId":418790,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418988.DA","ArtId":418988,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418798.DA","ArtId":418798,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419549.DA","ArtId":419549,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419568.DA","ArtId":419568,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"418867.DA","ArtId":418867,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419407.DA","ArtId":419407,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419576.DA","ArtId":419576,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422879.DA","ArtId":422879,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419437.DA","ArtId":419437,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419501.DA","ArtId":419501,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419546.DA","ArtId":419546,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419693.DA","ArtId":419693,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"415977.DA","ArtId":415977,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419600.DA","ArtId":419600,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419682.DA","ArtId":419682,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419495.DA","ArtId":419495,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419551.DA","ArtId":419551,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419683.DA","ArtId":419683,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419694.DA","ArtId":419694,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419488.DA","ArtId":419488,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419685.DA","ArtId":419685,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419452.DA","ArtId":419452,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419643.DA","ArtId":419643,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419687.DA","ArtId":419687,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419567.DA","ArtId":419567,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419720.DA","ArtId":419720,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"415990.DA","ArtId":415990,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419665.DA","ArtId":419665,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419664.DA","ArtId":419664,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419722.DA","ArtId":419722,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419672.DA","ArtId":419672,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419676.DA","ArtId":419676,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419601.DA","ArtId":419601,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419620.DA","ArtId":419620,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419617.DA","ArtId":419617,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419721.DA","ArtId":419721,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"424152.DA","ArtId":424152,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419628.DA","ArtId":419628,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419492.DA","ArtId":419492,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419514.DA","ArtId":419514,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419515.DA","ArtId":419515,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419436.DA","ArtId":419436,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419719.DA","ArtId":419719,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"Event","Type":"ArtStyle","Id":"417888.JP","ArtId":417888,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419536.DA","ArtId":419536,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419528.DA","ArtId":419528,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419527.DA","ArtId":419527,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419593.DA","ArtId":419593,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419446.DA","ArtId":419446,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"415986.DA","ArtId":415986,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419468.DA","ArtId":419468,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419602.DA","ArtId":419602,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419466.DA","ArtId":419466,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419690.DA","ArtId":419690,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419692.DA","ArtId":419692,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419718.DA","ArtId":419718,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419651.DA","ArtId":419651,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419473.DA","ArtId":419473,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419467.DA","ArtId":419467,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419630.DA","ArtId":419630,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419688.DA","ArtId":419688,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419476.DA","ArtId":419476,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421125.DA","ArtId":421125,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417889.JP","ArtId":417889,"Variant":"JP","ExplicitGrpIds":[]},{"AcquisitionFlags":"Event","Type":"ArtStyle","Id":"417868.JP","ArtId":417868,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417340.DA","ArtId":417340,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421130.DA","ArtId":421130,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419511.DA","ArtId":419511,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421133.DA","ArtId":421133,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417319.DA","ArtId":417319,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421180.DA","ArtId":421180,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421284.DA","ArtId":421284,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421132.DA","ArtId":421132,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421237.DA","ArtId":421237,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421114.DA","ArtId":421114,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421162.DA","ArtId":421162,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417065.DA","ArtId":417065,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421259.DA","ArtId":421259,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417343.DA","ArtId":417343,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421343.DA","ArtId":421343,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417314.DA","ArtId":417314,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417066.DA","ArtId":417066,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421159.DA","ArtId":421159,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417063.DA","ArtId":417063,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421346.DA","ArtId":421346,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417332.DA","ArtId":417332,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421297.DA","ArtId":421297,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417361.DA","ArtId":417361,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421121.DA","ArtId":421121,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421170.DA","ArtId":421170,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421342.DA","ArtId":421342,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421212.DA","ArtId":421212,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421254.DA","ArtId":421254,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421150.DA","ArtId":421150,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421172.DA","ArtId":421172,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421184.DA","ArtId":421184,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421185.DA","ArtId":421185,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421198.DA","ArtId":421198,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421193.DA","ArtId":421193,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421205.DA","ArtId":421205,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421227.DA","ArtId":421227,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421229.DA","ArtId":421229,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417351.DA","ArtId":417351,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421242.DA","ArtId":421242,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421263.DA","ArtId":421263,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421270.DA","ArtId":421270,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421273.DA","ArtId":421273,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421282.DA","ArtId":421282,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421344.DA","ArtId":421344,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421283.DA","ArtId":421283,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421303.DA","ArtId":421303,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422142.DA","ArtId":422142,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422322.DA","ArtId":422322,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"417325.DA","ArtId":417325,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421142.DA","ArtId":421142,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422152.DA","ArtId":422152,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422167.DA","ArtId":422167,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"422148.DA","ArtId":422148,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"422213.DA","ArtId":422213,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"443063.DA","ArtId":443063,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418126.SCHEMATIC","ArtId":418126,"Variant":"SCHEMATIC","ExplicitGrpIds":[]}],"Avatars":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_ChandraNalaar","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_AjaniGoldmane","Type":"Avatar"},{"Id":"Avatar_Basic_GideonJura","Type":"Avatar"},{"Id":"Avatar_Basic_Teferi","Type":"Avatar"},{"Id":"Avatar_Basic_SarkhanVol","Type":"Avatar"},{"Id":"Avatar_Basic_Tezzeret","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_VivienReid","Type":"Avatar"},{"Id":"Avatar_Basic_NissaRevane","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_LilianaVess","Type":"Avatar"},{"Id":"Avatar_Basic_Karn","Type":"Avatar"},{"Id":"Avatar_Basic_JayaBallard","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_JaceBeleren","Type":"Avatar"},{"Id":"Avatar_Basic_Ellywick_AFR","Type":"Avatar"},{"Id":"Avatar_Basic_Wrenn_MID","Type":"Avatar"},{"AcquisitionFlags":"CodeRedemption","Id":"Avatar_Basic_Sorin_VOW","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Elspeth_MOM","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Ashiok_WAR","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Kaito_NEO","Type":"Avatar"}],"Pets":[{"Type":"Pet","Id":"AFR_Dragon.Skin1","Name":"AFR_Dragon","Variant":"Skin1"},{"Type":"Pet","Id":"AFR_Dragon.Skin2","Name":"AFR_Dragon","Variant":"Skin2"},{"Type":"Pet","Id":"MID_Geist.Skin1","Name":"MID_Geist","Variant":"Skin1"},{"Type":"Pet","Id":"MID_Geist.Skin2","Name":"MID_Geist","Variant":"Skin2"},{"Type":"Pet","Id":"MID_Geist.Skin3","Name":"MID_Geist","Variant":"Skin3"},{"Type":"Pet","Id":"VOW_Bat.Level1","Name":"VOW_Bat","Variant":"Level1"},{"Type":"Pet","Id":"VOW_Bat.Level2","Name":"VOW_Bat","Variant":"Level2"},{"Type":"Pet","Id":"VOW_Bat.Level3","Name":"VOW_Bat","Variant":"Level3"}],"Sleeves":[{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_Basic_Thunderstorm_Bitterblossom","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418002","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418001","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418003","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418004","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418005","Type":"Sleeve"},{"Id":"CardBack_AFR_419749","Type":"Sleeve"},{"Id":"CardBack_AFR_419144","Type":"Sleeve"},{"Id":"CardBack_AFR_419111","Type":"Sleeve"},{"Id":"CardBack_MID_424253","Type":"Sleeve"},{"Id":"CardBack_MID_423524","Type":"Sleeve"},{"Id":"CardBack_ZNR_402686","Type":"Sleeve"},{"Id":"CardBack_MID_422493","Type":"Sleeve"},{"Id":"CardBack_VOW_424637","Type":"Sleeve"},{"Id":"CardBack_VOW_422028","Type":"Sleeve"},{"Id":"CardBack_VOW_422180","Type":"Sleeve"},{"Id":"CardBack_VOW_421278","Type":"Sleeve"},{"Id":"CardBack_VOW_421349","Type":"Sleeve"},{"AcquisitionFlags":"Event, CodeRedemption","Id":"CardBack_DvC_409074","Type":"Sleeve"}],"Emotes":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Hello","Type":"Emote","Category":"Greeting","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Nice_Thanks","Type":"Emote","FlipType":"Reply","Category":"Kudos","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Thinking_YourGo","Type":"Emote","FlipType":"Priority","Category":"Priority","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Oops_Sorry","Type":"Emote","FlipType":"Reply","Category":"Accident","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_GoodGame","Type":"Emote","Category":"GoodGame","Treatment":""}]}}}'
+    (
+        "P1P9 - Pack",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="DMU",
+            current_event="QuickDraft",
+            current_pack=1,
+            current_pick=9,
+            picks=["82091"],
+            pack=["82083","82196","82129","82170","82059","82160"],
+            card_pool=["82091"],
+            missing=["82309","82207","82165","82146","82120","82168","82091","82256"]
+        ),
+        r'{"CurrentModule":"BotDraft","Payload":"{\"Result\":\"Success\",\"EventName\":\"QuickDraft_DMU_20240507\",\"DraftStatus\":\"PickNext\",\"PackNumber\":0,\"PickNumber\":8,\"DraftPack\":[\"82083\",\"82196\",\"82129\",\"82170\",\"82059\",\"82160\"],\"PackStyles\":[],\"PickedCards\":[\"82091\",\"82140\",\"82065\",\"82124\",\"82303\",\"82123\",\"82249\",\"82309\"],\"PickedStyles\":[]}","DTO_InventoryInfo":{"SeqId":14,"Changes":[],"Gems":2300,"Gold":4500,"TotalVaultProgress":868,"wcTrackPosition":6,"WildCardCommons":68,"WildCardUnCommons":87,"WildCardRares":28,"WildCardMythics":12,"CustomTokens":{"BattlePass_AFR_Orb":1,"BattlePass_HBG_Orb":1,"BonusPackProgress":1,"BattlePass_MKM_Orb":1,"DraftToken":1},"Boosters":[{"CollationId":100026,"SetCode":"VOW","Count":10},{"CollationId":100024,"SetCode":"AFR","Count":7},{"CollationId":100020,"SetCode":"ZNR","Count":2},{"CollationId":100022,"SetCode":"KHM","Count":2},{"CollationId":100023,"SetCode":"STX","Count":3},{"CollationId":100025,"SetCode":"MID","Count":4},{"CollationId":100027,"SetCode":"NEO","Count":41},{"CollationId":100028,"SetCode":"SNC","Count":3},{"CollationId":400028,"SetCode":"Y22SNC","Count":1},{"CollationId":100029,"SetCode":"HBG","Count":8},{"CollationId":100030,"SetCode":"DMU","Count":1},{"CollationId":100031,"SetCode":"BRO","Count":1},{"CollationId":100032,"SetCode":"ONE","Count":3},{"CollationId":100033,"SetCode":"SIR","Count":3},{"CollationId":100037,"SetCode":"MOM","Count":3},{"CollationId":100039,"SetCode":"LTR","Count":3},{"CollationId":100040,"SetCode":"WOE","Count":3},{"CollationId":400031,"SetCode":"Y23BRO","Count":6},{"CollationId":400032,"SetCode":"Y23ONE","Count":3},{"CollationId":100038,"SetCode":"MAT","Count":3},{"CollationId":400040,"SetCode":"Y24WOE","Count":3},{"CollationId":400041,"SetCode":"Y24LCI","Count":3},{"CollationId":100042,"SetCode":"KTK","Count":3},{"CollationId":100041,"SetCode":"LCI","Count":4},{"CollationId":100043,"SetCode":"MKM","Count":6},{"CollationId":100044,"SetCode":"OTJ","Count":4},{"CollationId":400043,"SetCode":"Y24MKM","Count":3},{"CollationId":400044,"SetCode":"Y24OTJ","Count":3}],"Vouchers":{},"Cosmetics":{"ArtStyles":[{"Type":"ArtStyle","Id":"404952.DA","ArtId":404952,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"409037.DA","ArtId":409037,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"127296.DA","ArtId":127296,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"404505.DA","ArtId":404505,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"402637.DA","ArtId":402637,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"407656.DA","ArtId":407656,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418892.DA","ArtId":418892,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418903.DA","ArtId":418903,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"Event","Type":"ArtStyle","Id":"420249.JP","ArtId":420249,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416627.SH","ArtId":416627,"Variant":"SH","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417880.JP","ArtId":417880,"Variant":"JP","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406523.SG","ArtId":406523,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406664.SG","ArtId":406664,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"409514.SG","ArtId":409514,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406559.SG","ArtId":406559,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406626.SG","ArtId":406626,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"402959.DA","ArtId":402959,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"400332.DA","ArtId":400332,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"404135.DA","ArtId":404135,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"404488.DA","ArtId":404488,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"402057.DA","ArtId":402057,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418809.DA","ArtId":418809,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418895.DA","ArtId":418895,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418859.DA","ArtId":418859,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418963.DA","ArtId":418963,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418925.DA","ArtId":418925,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418777.DA","ArtId":418777,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418962.DA","ArtId":418962,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418781.DA","ArtId":418781,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418812.DA","ArtId":418812,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416383.DA","ArtId":416383,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416356.DA","ArtId":416356,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418912.DA","ArtId":418912,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418917.DA","ArtId":418917,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418785.DA","ArtId":418785,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418790.DA","ArtId":418790,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418988.DA","ArtId":418988,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418798.DA","ArtId":418798,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419549.DA","ArtId":419549,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419568.DA","ArtId":419568,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"418867.DA","ArtId":418867,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419407.DA","ArtId":419407,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419576.DA","ArtId":419576,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422879.DA","ArtId":422879,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419437.DA","ArtId":419437,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419501.DA","ArtId":419501,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419546.DA","ArtId":419546,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419693.DA","ArtId":419693,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"415977.DA","ArtId":415977,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419600.DA","ArtId":419600,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419682.DA","ArtId":419682,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419495.DA","ArtId":419495,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419551.DA","ArtId":419551,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419683.DA","ArtId":419683,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419694.DA","ArtId":419694,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419488.DA","ArtId":419488,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419685.DA","ArtId":419685,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419452.DA","ArtId":419452,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419643.DA","ArtId":419643,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419687.DA","ArtId":419687,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419567.DA","ArtId":419567,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419720.DA","ArtId":419720,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"415990.DA","ArtId":415990,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419665.DA","ArtId":419665,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419664.DA","ArtId":419664,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419722.DA","ArtId":419722,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419672.DA","ArtId":419672,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419676.DA","ArtId":419676,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419601.DA","ArtId":419601,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419620.DA","ArtId":419620,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419617.DA","ArtId":419617,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419721.DA","ArtId":419721,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"424152.DA","ArtId":424152,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419628.DA","ArtId":419628,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419492.DA","ArtId":419492,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419514.DA","ArtId":419514,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419515.DA","ArtId":419515,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419436.DA","ArtId":419436,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419719.DA","ArtId":419719,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"Event","Type":"ArtStyle","Id":"417888.JP","ArtId":417888,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419536.DA","ArtId":419536,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419528.DA","ArtId":419528,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419527.DA","ArtId":419527,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419593.DA","ArtId":419593,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419446.DA","ArtId":419446,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"415986.DA","ArtId":415986,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419468.DA","ArtId":419468,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419602.DA","ArtId":419602,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419466.DA","ArtId":419466,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419690.DA","ArtId":419690,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419692.DA","ArtId":419692,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419718.DA","ArtId":419718,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419651.DA","ArtId":419651,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419473.DA","ArtId":419473,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419467.DA","ArtId":419467,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419630.DA","ArtId":419630,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419688.DA","ArtId":419688,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419476.DA","ArtId":419476,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421125.DA","ArtId":421125,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417889.JP","ArtId":417889,"Variant":"JP","ExplicitGrpIds":[]},{"AcquisitionFlags":"Event","Type":"ArtStyle","Id":"417868.JP","ArtId":417868,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417340.DA","ArtId":417340,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421130.DA","ArtId":421130,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419511.DA","ArtId":419511,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421133.DA","ArtId":421133,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417319.DA","ArtId":417319,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421180.DA","ArtId":421180,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421284.DA","ArtId":421284,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421132.DA","ArtId":421132,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421237.DA","ArtId":421237,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421114.DA","ArtId":421114,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421162.DA","ArtId":421162,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417065.DA","ArtId":417065,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421259.DA","ArtId":421259,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417343.DA","ArtId":417343,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421343.DA","ArtId":421343,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417314.DA","ArtId":417314,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417066.DA","ArtId":417066,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421159.DA","ArtId":421159,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417063.DA","ArtId":417063,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421346.DA","ArtId":421346,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417332.DA","ArtId":417332,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421297.DA","ArtId":421297,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417361.DA","ArtId":417361,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421121.DA","ArtId":421121,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421170.DA","ArtId":421170,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421342.DA","ArtId":421342,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421212.DA","ArtId":421212,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421254.DA","ArtId":421254,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421150.DA","ArtId":421150,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421172.DA","ArtId":421172,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421184.DA","ArtId":421184,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421185.DA","ArtId":421185,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421198.DA","ArtId":421198,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421193.DA","ArtId":421193,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421205.DA","ArtId":421205,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421227.DA","ArtId":421227,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421229.DA","ArtId":421229,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417351.DA","ArtId":417351,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421242.DA","ArtId":421242,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421263.DA","ArtId":421263,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421270.DA","ArtId":421270,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421273.DA","ArtId":421273,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421282.DA","ArtId":421282,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421344.DA","ArtId":421344,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421283.DA","ArtId":421283,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421303.DA","ArtId":421303,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422142.DA","ArtId":422142,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422322.DA","ArtId":422322,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"417325.DA","ArtId":417325,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421142.DA","ArtId":421142,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422152.DA","ArtId":422152,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422167.DA","ArtId":422167,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"422148.DA","ArtId":422148,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"422213.DA","ArtId":422213,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"443063.DA","ArtId":443063,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418126.SCHEMATIC","ArtId":418126,"Variant":"SCHEMATIC","ExplicitGrpIds":[]}],"Avatars":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_ChandraNalaar","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_AjaniGoldmane","Type":"Avatar"},{"Id":"Avatar_Basic_GideonJura","Type":"Avatar"},{"Id":"Avatar_Basic_Teferi","Type":"Avatar"},{"Id":"Avatar_Basic_SarkhanVol","Type":"Avatar"},{"Id":"Avatar_Basic_Tezzeret","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_VivienReid","Type":"Avatar"},{"Id":"Avatar_Basic_NissaRevane","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_LilianaVess","Type":"Avatar"},{"Id":"Avatar_Basic_Karn","Type":"Avatar"},{"Id":"Avatar_Basic_JayaBallard","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_JaceBeleren","Type":"Avatar"},{"Id":"Avatar_Basic_Ellywick_AFR","Type":"Avatar"},{"Id":"Avatar_Basic_Wrenn_MID","Type":"Avatar"},{"AcquisitionFlags":"CodeRedemption","Id":"Avatar_Basic_Sorin_VOW","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Elspeth_MOM","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Ashiok_WAR","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Kaito_NEO","Type":"Avatar"}],"Pets":[{"Type":"Pet","Id":"AFR_Dragon.Skin1","Name":"AFR_Dragon","Variant":"Skin1"},{"Type":"Pet","Id":"AFR_Dragon.Skin2","Name":"AFR_Dragon","Variant":"Skin2"},{"Type":"Pet","Id":"MID_Geist.Skin1","Name":"MID_Geist","Variant":"Skin1"},{"Type":"Pet","Id":"MID_Geist.Skin2","Name":"MID_Geist","Variant":"Skin2"},{"Type":"Pet","Id":"MID_Geist.Skin3","Name":"MID_Geist","Variant":"Skin3"},{"Type":"Pet","Id":"VOW_Bat.Level1","Name":"VOW_Bat","Variant":"Level1"},{"Type":"Pet","Id":"VOW_Bat.Level2","Name":"VOW_Bat","Variant":"Level2"},{"Type":"Pet","Id":"VOW_Bat.Level3","Name":"VOW_Bat","Variant":"Level3"}],"Sleeves":[{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_Basic_Thunderstorm_Bitterblossom","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418002","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418001","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418003","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418004","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418005","Type":"Sleeve"},{"Id":"CardBack_AFR_419749","Type":"Sleeve"},{"Id":"CardBack_AFR_419144","Type":"Sleeve"},{"Id":"CardBack_AFR_419111","Type":"Sleeve"},{"Id":"CardBack_MID_424253","Type":"Sleeve"},{"Id":"CardBack_MID_423524","Type":"Sleeve"},{"Id":"CardBack_ZNR_402686","Type":"Sleeve"},{"Id":"CardBack_MID_422493","Type":"Sleeve"},{"Id":"CardBack_VOW_424637","Type":"Sleeve"},{"Id":"CardBack_VOW_422028","Type":"Sleeve"},{"Id":"CardBack_VOW_422180","Type":"Sleeve"},{"Id":"CardBack_VOW_421278","Type":"Sleeve"},{"Id":"CardBack_VOW_421349","Type":"Sleeve"},{"AcquisitionFlags":"Event, CodeRedemption","Id":"CardBack_DvC_409074","Type":"Sleeve"}],"Emotes":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Hello","Type":"Emote","Category":"Greeting","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Nice_Thanks","Type":"Emote","FlipType":"Reply","Category":"Kudos","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Thinking_YourGo","Type":"Emote","FlipType":"Priority","Category":"Priority","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Oops_Sorry","Type":"Emote","FlipType":"Reply","Category":"Accident","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_GoodGame","Type":"Emote","Category":"GoodGame","Treatment":""}]}}}'
     )
+]
+
+# Quick draft log entries collected from Player.log after the 2025-4-8 Arena Update
+TDM_QUICK_DRAFT_ENTRIES_2025_4_8 = [
+    (
+        "Event Start",
+        EventResults(
+            new_event=True,
+            data_update=False,
+            current_set="TDM",
+            current_event="QuickDraft",
+            current_pack=0,
+            current_pick=0,
+            picks=[],
+            pack=[],
+            card_pool=[],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]==> BotDraftDraftStatus {"id":"fc2ba2a1-ee38-450d-8645-d663ed59ed76","request":"{\"EventName\":\"QuickDraft_TDM_20250417\"}"}'
+    ),
+    (
+        "P1P5 - Pack",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="TDM",
+            current_event="QuickDraft",
+            current_pack=1,
+            current_pick=5,
+            picks=[],
+            pack=["95571","95632","95679","95566","95532","95650","95619","95651","95772","95786"],
+            card_pool=["95633","95679","95626","95746"],
+            missing=[]
+        ),
+        r'{"CurrentModule":"BotDraft","Payload":"{\"Result\":\"Success\",\"EventName\":\"QuickDraft_TDM_20250417\",\"DraftStatus\":\"PickNext\",\"PackNumber\":0,\"PickNumber\":4,\"NumCardsToPick\":1,\"DraftPack\":[\"95571\",\"95632\",\"95679\",\"95566\",\"95532\",\"95650\",\"95619\",\"95651\",\"95772\",\"95786\"],\"PackStyles\":[],\"PickedCards\":[\"95633\",\"95679\",\"95626\",\"95746\"],\"PickedStyles\":[]}"}'
+    ),
+    (
+        "P1P5 - Pick",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="TDM",
+            current_event="QuickDraft",
+            current_pack=1,
+            current_pick=5,
+            picks=["95772"],
+            pack=["95571","95632","95679","95566","95532","95650","95619","95651","95772","95786"],
+            card_pool=["95633","95679","95626","95746","95772"],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]==> BotDraftDraftPick {"id":"720e31b4-04ee-4a22-860e-008ab9d59030","request":"{\"EventName\":\"QuickDraft_TDM_20250417\",\"PickInfo\":{\"EventName\":\"QuickDraft_TDM_20250417\",\"CardId\":null,\"CardIds\":[\"95772\"],\"PackNumber\":0,\"PickNumber\":4}}"}'
+    ),
 ]
 
 # Traditional draft log entries collected from Player.log after 2024-5-7 Arena update
 OTJ_TRAD_DRAFT_ENTRIES_2024_5_7 = [
-    ("Event Start",
-    EventResults(new_event=True,
-                 data_update=False,
-                 current_set="OTJ",
-                 current_event="TradDraft",
-                 current_pack=0,
-                 current_pick=0,
-                 picks=[],
-                 pack=[],
-                 card_pool=[],
-                 missing=[]),
-    r'[UnityCrossThreadLogger]==> EventJoin {"id":"57d3b2c6-71ef-44ee-a395-1e977fcdd6b6","request":"{\"EventName\":\"TradDraft_OTJ_20240416\",\"EntryCurrencyType\":\"Gem\",\"EntryCurrencyPaid\":1500,\"CustomTokenId\":null}"}'
+    (
+        "Event Start",
+        EventResults(
+            new_event=True,
+            data_update=False,
+            current_set="OTJ",
+            current_event="TradDraft",
+            current_pack=0,
+            current_pick=0,
+            picks=[],
+            pack=[],
+            card_pool=[],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]==> Event_Join {"id":"57d3b2c6-71ef-44ee-a395-1e977fcdd6b6","request":"{\"EventName\":\"TradDraft_OTJ_20240416\",\"EntryCurrencyType\":\"Gem\",\"EntryCurrencyPaid\":1500,\"CustomTokenId\":null}"}'
     ),
-    ("P1P1 - Pack",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="OTJ",
-                 current_event="TradDraft",
-                 current_pack=1,
-                 current_pick=1,
-                 picks=[],
-                 pack=["90711","90515","90623","90686","90354","90571","90418","90511","90468","90429","90432","90458","90456","90593"], 
-                 card_pool=[],
-                 missing=[]),
-    r'[UnityCrossThreadLogger]==> LogBusinessEvents {"id":"f78e3f9d-6368-4bcc-98aa-7bd0297f29c0","request":"{\"PlayerId\":null,\"ClientPlatform\":null,\"DraftId\":\"df799bea-cba5-4acc-b7e0-bf3b742e6fb7\",\"EventId\":\"TradDraft_OTJ_20240416\",\"SeatNumber\":6,\"PackNumber\":1,\"PickNumber\":1,\"PickGrpId\":90686,\"CardsInPack\":[90711,90515,90623,90686,90354,90571,90418,90511,90468,90429,90432,90458,90456,90593],\"AutoPick\":false,\"TimeRemainingOnPick\":63.9975624,\"EventType\":24,\"EventTime\":\"2024-05-09T16:33:01.828189Z\"}"}'
+    (
+        "P1P1 - Pack",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="OTJ",
+            current_event="TradDraft",
+            current_pack=1,
+            current_pick=1,
+            picks=[],
+            pack=["90711","90515","90623","90686","90354","90571","90418","90511","90468","90429","90432","90458","90456","90593"], 
+            card_pool=[],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]==> LogBusinessEvents {"id":"f78e3f9d-6368-4bcc-98aa-7bd0297f29c0","request":"{\"PlayerId\":null,\"ClientPlatform\":null,\"DraftId\":\"df799bea-cba5-4acc-b7e0-bf3b742e6fb7\",\"EventId\":\"TradDraft_OTJ_20240416\",\"SeatNumber\":6,\"PackNumber\":1,\"PickNumber\":1,\"PickGrpId\":90686,\"CardsInPack\":[90711,90515,90623,90686,90354,90571,90418,90511,90468,90429,90432,90458,90456,90593],\"AutoPick\":false,\"TimeRemainingOnPick\":63.9975624,\"EventType\":24,\"EventTime\":\"2024-05-09T16:33:01.828189Z\"}"}'
     ),
-    ("P1P1 - Pick",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="OTJ",
-                 current_event="TradDraft",
-                 current_pack=1,
-                 current_pick=1,
-                 picks=["90686"],
-                 pack=["90711","90515","90623","90686","90354","90571","90418","90511","90468","90429","90432","90458","90456","90593"],  
-                 card_pool=["90686"],
-                 missing=[]),
-    r'[UnityCrossThreadLogger]==> EventPlayerDraftMakePick {"id":"f803188b-1de3-4ad5-bfed-7a3cefdb6598","request":"{\"DraftId\":\"df799bea-cba5-4acc-b7e0-bf3b742e6fb7\",\"GrpIds\":[90686],\"Pack\":1,\"Pick\":1}"}'
+    (
+        "P1P1 - Pick",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="OTJ",
+            current_event="TradDraft",
+            current_pack=1,
+            current_pick=1,
+            picks=["90686"],
+            pack=["90711","90515","90623","90686","90354","90571","90418","90511","90468","90429","90432","90458","90456","90593"],  
+            card_pool=["90686"],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]==> Event_PlayerDraftMakePick {"id":"f803188b-1de3-4ad5-bfed-7a3cefdb6598","request":"{\"DraftId\":\"df799bea-cba5-4acc-b7e0-bf3b742e6fb7\",\"GrpId\":90686,\"Pack\":1,\"Pick\":1}"}'
     ),
-    ("P1P2 - Pack",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="OTJ",
-                 current_event="TradDraft",
-                 current_pack=1,
-                 current_pick=2,
-                 picks=[],
-                 pack=["90757","90461","90632","90667","90484","90440","90502","90476","90349","90418","90408","90466","90446"], 
-                 card_pool=["90686"],
-                 missing=[]),
-    r'[UnityCrossThreadLogger]Draft.Notify {"draftId":"df799bea-cba5-4acc-b7e0-bf3b742e6fb7","SelfPick":2,"SelfPack":1,"PackCards":"90757,90461,90632,90667,90484,90440,90502,90476,90349,90418,90408,90466,90446"}'
+    (
+        "P1P2 - Pack",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="OTJ",
+            current_event="TradDraft",
+            current_pack=1,
+            current_pick=2,
+            picks=[],
+            pack=["90757","90461","90632","90667","90484","90440","90502","90476","90349","90418","90408","90466","90446"], 
+            card_pool=["90686"],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]Draft.Notify {"draftId":"df799bea-cba5-4acc-b7e0-bf3b742e6fb7","SelfPick":2,"SelfPack":1,"PackCards":"90757,90461,90632,90667,90484,90440,90502,90476,90349,90418,90408,90466,90446"}'
     ),
-    ("P1P9 - Pack",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="OTJ",
-                 current_event="TradDraft",
-                 current_pack=1,
-                 current_pick=9,
-                 picks=["90686"],
-                 pack=["90711","90623","90571","90432","90456","90593"],
-                 card_pool=["90686"],
-                 missing=["90515","90686","90354","90418","90511","90468","90429","90458"]),
-    r'[UnityCrossThreadLogger]Draft.Notify {"draftId":"df799bea-cba5-4acc-b7e0-bf3b742e6fb7","SelfPick":9,"SelfPack":1,"PackCards":"90711,90623,90571,90432,90456,90593"}'
+    (
+        "P1P9 - Pack",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="OTJ",
+            current_event="TradDraft",
+            current_pack=1,
+            current_pick=9,
+            picks=["90686"],
+            pack=["90711","90623","90571","90432","90456","90593"],
+            card_pool=["90686"],
+            missing=["90515","90686","90354","90418","90511","90468","90429","90458"]
+        ),
+        r'[UnityCrossThreadLogger]Draft.Notify {"draftId":"df799bea-cba5-4acc-b7e0-bf3b742e6fb7","SelfPick":9,"SelfPack":1,"PackCards":"90711,90623,90571,90432,90456,90593"}'
     ),
-    ("P3P14 - Pack",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="OTJ",
-                 current_event="TradDraft",
-                 current_pack=3,
-                 current_pick=14,
-                 picks=[],
-                 pack=["90383"],
-                 card_pool=["90686"],
-                 missing=[]),
-    r'[UnityCrossThreadLogger]Draft.Notify {"draftId":"df799bea-cba5-4acc-b7e0-bf3b742e6fb7","SelfPick":14,"SelfPack":3,"PackCards":"90383"}'
+    (
+        "P3P14 - Pack",
+        EventResults(
+            new_event=False,
+            data_update=True,
+            current_set="OTJ",
+            current_event="TradDraft",
+            current_pack=3,
+            current_pick=14,
+            picks=[],
+            pack=["90383"],
+            card_pool=["90686"],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]Draft.Notify {"draftId":"df799bea-cba5-4acc-b7e0-bf3b742e6fb7","SelfPick":14,"SelfPack":3,"PackCards":"90383"}'
     )
 ]
 
 # Sealedlog entries collected from Player.log after 2024-9-24 Arena update
 DSK_SEALED_ENTRIES_2024_9_24 = [
-    ("Event Start",
-    EventResults(new_event=True,
-                 data_update=False,
-                 current_set="DSK",
-                 current_event="Sealed",
-                 current_pack=0,
-                 current_pick=0,
-                 picks=[],
-                 pack=[],
-                 card_pool=[],
-                 missing=[]),
-    r'[UnityCrossThreadLogger]==> EventJoin {"id":"54d60b67-59a9-4188-bc42-ab78fed44fad","request":"{\"EventName\":\"Sealed_DSK_20240924\",\"EntryCurrencyType\":\"Gem\",\"EntryCurrencyPaid\":2000,\"CustomTokenId\":null}"}'
+    (
+        "Event Start",
+        EventResults(
+            new_event=True,
+            data_update=False,
+            current_set="DSK",
+            current_event="Sealed",
+            current_pack=0,
+            current_pick=0,
+            picks=[],
+            pack=[],
+            card_pool=[],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]==> Event_Join {"id":"54d60b67-59a9-4188-bc42-ab78fed44fad","request":"{\"EventName\":\"Sealed_DSK_20240924\",\"EntryCurrencyType\":\"Gem\",\"EntryCurrencyPaid\":2000,\"CustomTokenId\":null}"}'
     ),
-    ("Card Pool",
-    EventResults(new_event=False,
-                 data_update=True,
-                 current_set="DSK",
-                 current_event="Sealed",
-                 current_pack=0,
-                 current_pick=0,
-                 picks=[],
-                 pack=[], 
-                 card_pool=["92248","92368","92257","92188","92143","92242","92055","92154","92149","92238","92162","92261","92350","92338","92307","92379","92154","92073","92167","92203","92143","92291","92219","92235","92127","92311","92208","92230","92201","92364","92073","92268","92111","92181","92236","92146","92267","92116","92185","92304","92066","92313","92076","92365","92156","92146","92343","92237","92369","92274","92055","92067","92308","92234","92265","92360","92212","92380","92172","92279","92148","92073","92154","92179","92224","92141","92316","92305","92342","92092","92266","92377","92279","92240","92148","92114","92172","92070","92290","92229","92090","92182","92113","92119"],
-                 missing=[]),
-    r'{"Course":{"CourseId":"d276ee0e-a180-41f9-b41a-8249c1db4bdf","InternalEventName":"Sealed_DSK_20240924","CurrentModule":"DeckSelect","ModulePayload":"","CourseDeckSummary":{"Attributes":[],"FormatLegalities":{},"PreferredCosmetics":{},"DeckValidationSummaries":[],"UnownedCards":{}},"CardPool":[92248,92368,92257,92188,92143,92242,92055,92154,92149,92238,92162,92261,92350,92338,92307,92379,92154,92073,92167,92203,92143,92291,92219,92235,92127,92311,92208,92230,92201,92364,92073,92268,92111,92181,92236,92146,92267,92116,92185,92304,92066,92313,92076,92365,92156,92146,92343,92237,92369,92274,92055,92067,92308,92234,92265,92360,92212,92380,92172,92279,92148,92073,92154,92179,92224,92141,92316,92305,92342,92092,92266,92377,92279,92240,92148,92114,92172,92070,92290,92229,92090,92182,92113,92119],"CardStyles":[]},"InventoryInfo":{"SeqId":9,"Changes":[{"Source":"EventPayEntry","SourceId":"d276ee0e-a180-41f9-b41a-8249c1db4bdf","InventoryGems":-2000,"InventoryCustomTokens":{},"ArtStyles":[],"Avatars":[],"Sleeves":[],"Pets":[],"Emotes":[],"Titles":[],"Decks":[],"DecksV2":[],"DeckCards":{},"Boosters":[],"GrantedCards":[],"Vouchers":{},"NewLetters":[],"PrizeWallsUnlocked":[]},{"Source":"EventGrantCardPool","SourceId":"Sealed_DSK_20240924","InventoryCustomTokens":{},"ArtStyles":[],"Avatars":[],"Sleeves":[],"Pets":[],"Emotes":[],"Titles":[],"Decks":[],"DecksV2":[],"DeckCards":{},"Boosters":[],"GrantedCards":[{"GrpId":92248,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92368,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92257,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92188,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92143,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92143,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92242,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92055,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92055,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92154,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92154,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92154,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92149,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92238,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92162,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92261,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92350,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92338,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92307,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92073,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92073,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92073,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92167,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92203,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92291,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92219,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92235,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92127,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92311,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92208,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92230,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92201,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92364,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92268,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92111,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92181,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92236,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92146,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92146,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92267,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92116,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92185,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92304,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92066,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92313,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92076,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92365,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92156,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92343,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92237,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92369,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92274,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92067,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92308,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92234,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92265,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92360,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92212,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92172,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92172,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92279,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92279,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92148,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92148,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92179,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92224,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92141,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92316,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92305,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92342,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92092,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92266,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92240,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92114,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92070,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92290,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92229,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92090,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92182,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92113,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92119,"CardAdded":true,"SetCode":"DSK"}],"Vouchers":{},"NewLetters":[],"PrizeWallsUnlocked":[]}],"Gems":350,"Gold":4500,"TotalVaultProgress":869,"wcTrackPosition":6,"WildCardCommons":68,"WildCardUnCommons":87,"WildCardRares":28,"WildCardMythics":12,"CustomTokens":{"BattlePass_AFR_Orb":1,"BattlePass_HBG_Orb":1,"BonusPackProgress":1,"BattlePass_MKM_Orb":1,"DraftToken":1},"Boosters":[{"CollationId":100026,"SetCode":"VOW","Count":10},{"CollationId":100024,"SetCode":"AFR","Count":7},{"CollationId":100020,"SetCode":"ZNR","Count":2},{"CollationId":100022,"SetCode":"KHM","Count":2},{"CollationId":100023,"SetCode":"STX","Count":3},{"CollationId":100025,"SetCode":"MID","Count":4},{"CollationId":100027,"SetCode":"NEO","Count":41},{"CollationId":100028,"SetCode":"SNC","Count":3},{"CollationId":400028,"SetCode":"Y22SNC","Count":1},{"CollationId":100029,"SetCode":"HBG","Count":8},{"CollationId":100030,"SetCode":"DMU","Count":2},{"CollationId":100031,"SetCode":"BRO","Count":1},{"CollationId":100032,"SetCode":"ONE","Count":3},{"CollationId":100033,"SetCode":"SIR","Count":3},{"CollationId":100037,"SetCode":"MOM","Count":3},{"CollationId":100039,"SetCode":"LTR","Count":3},{"CollationId":100040,"SetCode":"WOE","Count":3},{"CollationId":400031,"SetCode":"Y23BRO","Count":6},{"CollationId":400032,"SetCode":"Y23ONE","Count":3},{"CollationId":100038,"SetCode":"MAT","Count":3},{"CollationId":400040,"SetCode":"Y24WOE","Count":3},{"CollationId":400041,"SetCode":"Y24LCI","Count":3},{"CollationId":100042,"SetCode":"KTK","Count":3},{"CollationId":100041,"SetCode":"LCI","Count":4},{"CollationId":100043,"SetCode":"MKM","Count":6},{"CollationId":100044,"SetCode":"OTJ","Count":4},{"CollationId":400043,"SetCode":"Y24MKM","Count":3},{"CollationId":400044,"SetCode":"Y24OTJ","Count":3},{"CollationId":100046,"SetCode":"BLB","Count":3},{"CollationId":400046,"SetCode":"Y25BLB","Count":3},{"CollationId":100045,"SetCode":"MH3","Count":3},{"CollationId":100047,"SetCode":"DSK","Count":3}],"Vouchers":{},"PrizeWallsUnlocked":[],"Cosmetics":{"ArtStyles":[{"Type":"ArtStyle","Id":"404952.DA","ArtId":404952,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"409037.DA","ArtId":409037,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"127296.DA","ArtId":127296,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"404505.DA","ArtId":404505,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"402637.DA","ArtId":402637,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"407656.DA","ArtId":407656,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418892.DA","ArtId":418892,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418903.DA","ArtId":418903,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"Event","Type":"ArtStyle","Id":"420249.JP","ArtId":420249,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416627.SH","ArtId":416627,"Variant":"SH","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417880.JP","ArtId":417880,"Variant":"JP","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406523.SG","ArtId":406523,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406664.SG","ArtId":406664,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"409514.SG","ArtId":409514,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406559.SG","ArtId":406559,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406626.SG","ArtId":406626,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"402959.DA","ArtId":402959,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"400332.DA","ArtId":400332,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"404135.DA","ArtId":404135,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"404488.DA","ArtId":404488,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"402057.DA","ArtId":402057,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418809.DA","ArtId":418809,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418895.DA","ArtId":418895,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418859.DA","ArtId":418859,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418963.DA","ArtId":418963,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418925.DA","ArtId":418925,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418777.DA","ArtId":418777,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418962.DA","ArtId":418962,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418781.DA","ArtId":418781,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418812.DA","ArtId":418812,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416383.DA","ArtId":416383,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416356.DA","ArtId":416356,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418912.DA","ArtId":418912,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418917.DA","ArtId":418917,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418785.DA","ArtId":418785,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418790.DA","ArtId":418790,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418988.DA","ArtId":418988,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418798.DA","ArtId":418798,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419549.DA","ArtId":419549,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419568.DA","ArtId":419568,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"418867.DA","ArtId":418867,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419407.DA","ArtId":419407,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419576.DA","ArtId":419576,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422879.DA","ArtId":422879,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419437.DA","ArtId":419437,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419501.DA","ArtId":419501,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419546.DA","ArtId":419546,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419693.DA","ArtId":419693,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"415977.DA","ArtId":415977,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419600.DA","ArtId":419600,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419682.DA","ArtId":419682,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419495.DA","ArtId":419495,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419551.DA","ArtId":419551,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419683.DA","ArtId":419683,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419694.DA","ArtId":419694,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419488.DA","ArtId":419488,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419685.DA","ArtId":419685,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419452.DA","ArtId":419452,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419643.DA","ArtId":419643,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419687.DA","ArtId":419687,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419567.DA","ArtId":419567,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419720.DA","ArtId":419720,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"415990.DA","ArtId":415990,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419665.DA","ArtId":419665,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419664.DA","ArtId":419664,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419722.DA","ArtId":419722,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419672.DA","ArtId":419672,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419676.DA","ArtId":419676,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419601.DA","ArtId":419601,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419620.DA","ArtId":419620,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419617.DA","ArtId":419617,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419721.DA","ArtId":419721,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"424152.DA","ArtId":424152,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419628.DA","ArtId":419628,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419492.DA","ArtId":419492,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419514.DA","ArtId":419514,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419515.DA","ArtId":419515,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419436.DA","ArtId":419436,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419719.DA","ArtId":419719,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"Event","Type":"ArtStyle","Id":"417888.JP","ArtId":417888,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419536.DA","ArtId":419536,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419528.DA","ArtId":419528,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419527.DA","ArtId":419527,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419593.DA","ArtId":419593,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419446.DA","ArtId":419446,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"415986.DA","ArtId":415986,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419468.DA","ArtId":419468,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419602.DA","ArtId":419602,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419466.DA","ArtId":419466,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419690.DA","ArtId":419690,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419692.DA","ArtId":419692,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419718.DA","ArtId":419718,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419651.DA","ArtId":419651,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419473.DA","ArtId":419473,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419467.DA","ArtId":419467,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419630.DA","ArtId":419630,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419688.DA","ArtId":419688,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419476.DA","ArtId":419476,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421125.DA","ArtId":421125,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417889.JP","ArtId":417889,"Variant":"JP","ExplicitGrpIds":[]},{"AcquisitionFlags":"Event","Type":"ArtStyle","Id":"417868.JP","ArtId":417868,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417340.DA","ArtId":417340,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421130.DA","ArtId":421130,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419511.DA","ArtId":419511,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421133.DA","ArtId":421133,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417319.DA","ArtId":417319,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421180.DA","ArtId":421180,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421284.DA","ArtId":421284,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421132.DA","ArtId":421132,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421237.DA","ArtId":421237,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421114.DA","ArtId":421114,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421162.DA","ArtId":421162,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417065.DA","ArtId":417065,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421259.DA","ArtId":421259,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417343.DA","ArtId":417343,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421343.DA","ArtId":421343,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417314.DA","ArtId":417314,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417066.DA","ArtId":417066,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421159.DA","ArtId":421159,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417063.DA","ArtId":417063,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421346.DA","ArtId":421346,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417332.DA","ArtId":417332,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421297.DA","ArtId":421297,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417361.DA","ArtId":417361,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421121.DA","ArtId":421121,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421170.DA","ArtId":421170,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421342.DA","ArtId":421342,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421212.DA","ArtId":421212,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421254.DA","ArtId":421254,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421150.DA","ArtId":421150,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421172.DA","ArtId":421172,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421184.DA","ArtId":421184,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421185.DA","ArtId":421185,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421198.DA","ArtId":421198,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421193.DA","ArtId":421193,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421205.DA","ArtId":421205,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421227.DA","ArtId":421227,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421229.DA","ArtId":421229,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417351.DA","ArtId":417351,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421242.DA","ArtId":421242,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421263.DA","ArtId":421263,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421270.DA","ArtId":421270,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421273.DA","ArtId":421273,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421282.DA","ArtId":421282,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421344.DA","ArtId":421344,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421283.DA","ArtId":421283,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421303.DA","ArtId":421303,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422142.DA","ArtId":422142,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422322.DA","ArtId":422322,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"417325.DA","ArtId":417325,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421142.DA","ArtId":421142,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422152.DA","ArtId":422152,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422167.DA","ArtId":422167,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"422148.DA","ArtId":422148,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"422213.DA","ArtId":422213,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"443063.DA","ArtId":443063,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418126.SCHEMATIC","ArtId":418126,"Variant":"SCHEMATIC","ExplicitGrpIds":[]}],"Avatars":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_ChandraNalaar","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_AjaniGoldmane","Type":"Avatar"},{"Id":"Avatar_Basic_GideonJura","Type":"Avatar"},{"Id":"Avatar_Basic_Teferi","Type":"Avatar"},{"Id":"Avatar_Basic_SarkhanVol","Type":"Avatar"},{"Id":"Avatar_Basic_Tezzeret","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_VivienReid","Type":"Avatar"},{"Id":"Avatar_Basic_NissaRevane","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_LilianaVess","Type":"Avatar"},{"Id":"Avatar_Basic_Karn","Type":"Avatar"},{"Id":"Avatar_Basic_JayaBallard","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_JaceBeleren","Type":"Avatar"},{"Id":"Avatar_Basic_Ellywick_AFR","Type":"Avatar"},{"Id":"Avatar_Basic_Wrenn_MID","Type":"Avatar"},{"AcquisitionFlags":"CodeRedemption","Id":"Avatar_Basic_Sorin_VOW","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Elspeth_MOM","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Ashiok_WAR","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Kaito_NEO","Type":"Avatar"}],"Pets":[{"Type":"Pet","Id":"AFR_Dragon.Skin1","Name":"AFR_Dragon","Variant":"Skin1"},{"Type":"Pet","Id":"AFR_Dragon.Skin2","Name":"AFR_Dragon","Variant":"Skin2"},{"Type":"Pet","Id":"MID_Geist.Skin1","Name":"MID_Geist","Variant":"Skin1"},{"Type":"Pet","Id":"MID_Geist.Skin2","Name":"MID_Geist","Variant":"Skin2"},{"Type":"Pet","Id":"MID_Geist.Skin3","Name":"MID_Geist","Variant":"Skin3"},{"Type":"Pet","Id":"VOW_Bat.Level1","Name":"VOW_Bat","Variant":"Level1"},{"Type":"Pet","Id":"VOW_Bat.Level2","Name":"VOW_Bat","Variant":"Level2"},{"Type":"Pet","Id":"VOW_Bat.Level3","Name":"VOW_Bat","Variant":"Level3"}],"Sleeves":[{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_Basic_Thunderstorm_Bitterblossom","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418002","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418001","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418003","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418004","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418005","Type":"Sleeve"},{"Id":"CardBack_AFR_419749","Type":"Sleeve"},{"Id":"CardBack_AFR_419144","Type":"Sleeve"},{"Id":"CardBack_AFR_419111","Type":"Sleeve"},{"Id":"CardBack_MID_424253","Type":"Sleeve"},{"Id":"CardBack_MID_423524","Type":"Sleeve"},{"Id":"CardBack_ZNR_402686","Type":"Sleeve"},{"Id":"CardBack_MID_422493","Type":"Sleeve"},{"Id":"CardBack_VOW_424637","Type":"Sleeve"},{"Id":"CardBack_VOW_422028","Type":"Sleeve"},{"Id":"CardBack_VOW_422180","Type":"Sleeve"},{"Id":"CardBack_VOW_421278","Type":"Sleeve"},{"Id":"CardBack_VOW_421349","Type":"Sleeve"},{"AcquisitionFlags":"Event, CodeRedemption","Id":"CardBack_DvC_409074","Type":"Sleeve"},{"Id":"CardBack_DG_MemorialSleeve","Type":"Sleeve"}],"Emotes":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Hello","Type":"Emote","Category":"Greeting","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Nice_Thanks","Type":"Emote","FlipType":"Reply","Category":"Kudos","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Thinking_YourGo","Type":"Emote","FlipType":"Priority","Category":"Priority","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Oops_Sorry","Type":"Emote","FlipType":"Reply","Category":"Accident","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_GoodGame","Type":"Emote","Category":"GoodGame","Treatment":""}],"Titles":[]}}}'
+    (
+        "Card Pool",
+        EventResults(new_event=False,
+                    data_update=True,
+                    current_set="DSK",
+                    current_event="Sealed",
+                    current_pack=0,
+                    current_pick=0,
+                    picks=[],
+                    pack=[], 
+                    card_pool=["92248","92368","92257","92188","92143","92242","92055","92154","92149","92238","92162","92261","92350","92338","92307","92379","92154","92073","92167","92203","92143","92291","92219","92235","92127","92311","92208","92230","92201","92364","92073","92268","92111","92181","92236","92146","92267","92116","92185","92304","92066","92313","92076","92365","92156","92146","92343","92237","92369","92274","92055","92067","92308","92234","92265","92360","92212","92380","92172","92279","92148","92073","92154","92179","92224","92141","92316","92305","92342","92092","92266","92377","92279","92240","92148","92114","92172","92070","92290","92229","92090","92182","92113","92119"],
+                    missing=[]
+        ),
+        r'{"Course":{"CourseId":"d276ee0e-a180-41f9-b41a-8249c1db4bdf","InternalEventName":"Sealed_DSK_20240924","CurrentModule":"DeckSelect","ModulePayload":"","CourseDeckSummary":{"Attributes":[],"FormatLegalities":{},"PreferredCosmetics":{},"DeckValidationSummaries":[],"UnownedCards":{}},"CardPool":[92248,92368,92257,92188,92143,92242,92055,92154,92149,92238,92162,92261,92350,92338,92307,92379,92154,92073,92167,92203,92143,92291,92219,92235,92127,92311,92208,92230,92201,92364,92073,92268,92111,92181,92236,92146,92267,92116,92185,92304,92066,92313,92076,92365,92156,92146,92343,92237,92369,92274,92055,92067,92308,92234,92265,92360,92212,92380,92172,92279,92148,92073,92154,92179,92224,92141,92316,92305,92342,92092,92266,92377,92279,92240,92148,92114,92172,92070,92290,92229,92090,92182,92113,92119],"CardStyles":[]},"InventoryInfo":{"SeqId":9,"Changes":[{"Source":"EventPayEntry","SourceId":"d276ee0e-a180-41f9-b41a-8249c1db4bdf","InventoryGems":-2000,"InventoryCustomTokens":{},"ArtStyles":[],"Avatars":[],"Sleeves":[],"Pets":[],"Emotes":[],"Titles":[],"Decks":[],"DecksV2":[],"DeckCards":{},"Boosters":[],"GrantedCards":[],"Vouchers":{},"NewLetters":[],"PrizeWallsUnlocked":[]},{"Source":"EventGrantCardPool","SourceId":"Sealed_DSK_20240924","InventoryCustomTokens":{},"ArtStyles":[],"Avatars":[],"Sleeves":[],"Pets":[],"Emotes":[],"Titles":[],"Decks":[],"DecksV2":[],"DeckCards":{},"Boosters":[],"GrantedCards":[{"GrpId":92248,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92368,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92257,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92188,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92143,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92143,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92242,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92055,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92055,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92154,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92154,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92154,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92149,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92238,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92162,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92261,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92350,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92338,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92307,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92073,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92073,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92073,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92167,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92203,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92291,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92219,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92235,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92127,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92311,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92208,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92230,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92201,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92364,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92268,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92111,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92181,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92236,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92146,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92146,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92267,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92116,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92185,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92304,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92066,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92313,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92076,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92365,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92156,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92343,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92237,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92369,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92274,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92067,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92308,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92234,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92265,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92360,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92212,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92172,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92172,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92279,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92279,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92148,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92148,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92179,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92224,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92141,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92316,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92305,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92342,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92092,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92266,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92240,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92114,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92070,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92290,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92229,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92090,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92182,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92113,"CardAdded":true,"SetCode":"DSK"},{"GrpId":92119,"CardAdded":true,"SetCode":"DSK"}],"Vouchers":{},"NewLetters":[],"PrizeWallsUnlocked":[]}],"Gems":350,"Gold":4500,"TotalVaultProgress":869,"wcTrackPosition":6,"WildCardCommons":68,"WildCardUnCommons":87,"WildCardRares":28,"WildCardMythics":12,"CustomTokens":{"BattlePass_AFR_Orb":1,"BattlePass_HBG_Orb":1,"BonusPackProgress":1,"BattlePass_MKM_Orb":1,"DraftToken":1},"Boosters":[{"CollationId":100026,"SetCode":"VOW","Count":10},{"CollationId":100024,"SetCode":"AFR","Count":7},{"CollationId":100020,"SetCode":"ZNR","Count":2},{"CollationId":100022,"SetCode":"KHM","Count":2},{"CollationId":100023,"SetCode":"STX","Count":3},{"CollationId":100025,"SetCode":"MID","Count":4},{"CollationId":100027,"SetCode":"NEO","Count":41},{"CollationId":100028,"SetCode":"SNC","Count":3},{"CollationId":400028,"SetCode":"Y22SNC","Count":1},{"CollationId":100029,"SetCode":"HBG","Count":8},{"CollationId":100030,"SetCode":"DMU","Count":2},{"CollationId":100031,"SetCode":"BRO","Count":1},{"CollationId":100032,"SetCode":"ONE","Count":3},{"CollationId":100033,"SetCode":"SIR","Count":3},{"CollationId":100037,"SetCode":"MOM","Count":3},{"CollationId":100039,"SetCode":"LTR","Count":3},{"CollationId":100040,"SetCode":"WOE","Count":3},{"CollationId":400031,"SetCode":"Y23BRO","Count":6},{"CollationId":400032,"SetCode":"Y23ONE","Count":3},{"CollationId":100038,"SetCode":"MAT","Count":3},{"CollationId":400040,"SetCode":"Y24WOE","Count":3},{"CollationId":400041,"SetCode":"Y24LCI","Count":3},{"CollationId":100042,"SetCode":"KTK","Count":3},{"CollationId":100041,"SetCode":"LCI","Count":4},{"CollationId":100043,"SetCode":"MKM","Count":6},{"CollationId":100044,"SetCode":"OTJ","Count":4},{"CollationId":400043,"SetCode":"Y24MKM","Count":3},{"CollationId":400044,"SetCode":"Y24OTJ","Count":3},{"CollationId":100046,"SetCode":"BLB","Count":3},{"CollationId":400046,"SetCode":"Y25BLB","Count":3},{"CollationId":100045,"SetCode":"MH3","Count":3},{"CollationId":100047,"SetCode":"DSK","Count":3}],"Vouchers":{},"PrizeWallsUnlocked":[],"Cosmetics":{"ArtStyles":[{"Type":"ArtStyle","Id":"404952.DA","ArtId":404952,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"409037.DA","ArtId":409037,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"127296.DA","ArtId":127296,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"404505.DA","ArtId":404505,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"402637.DA","ArtId":402637,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"407656.DA","ArtId":407656,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418892.DA","ArtId":418892,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418903.DA","ArtId":418903,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"Event","Type":"ArtStyle","Id":"420249.JP","ArtId":420249,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416627.SH","ArtId":416627,"Variant":"SH","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417880.JP","ArtId":417880,"Variant":"JP","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406523.SG","ArtId":406523,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406664.SG","ArtId":406664,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"409514.SG","ArtId":409514,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406559.SG","ArtId":406559,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"406626.SG","ArtId":406626,"Variant":"SG","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"402959.DA","ArtId":402959,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"400332.DA","ArtId":400332,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"404135.DA","ArtId":404135,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"404488.DA","ArtId":404488,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"CodeRedemption","Type":"ArtStyle","Id":"402057.DA","ArtId":402057,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418809.DA","ArtId":418809,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418895.DA","ArtId":418895,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418859.DA","ArtId":418859,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418963.DA","ArtId":418963,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418925.DA","ArtId":418925,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418777.DA","ArtId":418777,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418962.DA","ArtId":418962,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418781.DA","ArtId":418781,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418812.DA","ArtId":418812,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416383.DA","ArtId":416383,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"416356.DA","ArtId":416356,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418912.DA","ArtId":418912,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418917.DA","ArtId":418917,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418785.DA","ArtId":418785,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418790.DA","ArtId":418790,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418988.DA","ArtId":418988,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418798.DA","ArtId":418798,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419549.DA","ArtId":419549,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419568.DA","ArtId":419568,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"418867.DA","ArtId":418867,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419407.DA","ArtId":419407,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419576.DA","ArtId":419576,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422879.DA","ArtId":422879,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419437.DA","ArtId":419437,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419501.DA","ArtId":419501,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419546.DA","ArtId":419546,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419693.DA","ArtId":419693,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"415977.DA","ArtId":415977,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419600.DA","ArtId":419600,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419682.DA","ArtId":419682,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419495.DA","ArtId":419495,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419551.DA","ArtId":419551,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419683.DA","ArtId":419683,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419694.DA","ArtId":419694,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419488.DA","ArtId":419488,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419685.DA","ArtId":419685,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419452.DA","ArtId":419452,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419643.DA","ArtId":419643,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419687.DA","ArtId":419687,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419567.DA","ArtId":419567,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419720.DA","ArtId":419720,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"415990.DA","ArtId":415990,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419665.DA","ArtId":419665,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419664.DA","ArtId":419664,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419722.DA","ArtId":419722,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419672.DA","ArtId":419672,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419676.DA","ArtId":419676,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419601.DA","ArtId":419601,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419620.DA","ArtId":419620,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419617.DA","ArtId":419617,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419721.DA","ArtId":419721,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"424152.DA","ArtId":424152,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419628.DA","ArtId":419628,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419492.DA","ArtId":419492,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419514.DA","ArtId":419514,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419515.DA","ArtId":419515,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419436.DA","ArtId":419436,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419719.DA","ArtId":419719,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"Event","Type":"ArtStyle","Id":"417888.JP","ArtId":417888,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419536.DA","ArtId":419536,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419528.DA","ArtId":419528,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419527.DA","ArtId":419527,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419593.DA","ArtId":419593,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419446.DA","ArtId":419446,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"415986.DA","ArtId":415986,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419468.DA","ArtId":419468,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419602.DA","ArtId":419602,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419466.DA","ArtId":419466,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419690.DA","ArtId":419690,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419692.DA","ArtId":419692,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419718.DA","ArtId":419718,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419651.DA","ArtId":419651,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419473.DA","ArtId":419473,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419467.DA","ArtId":419467,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419630.DA","ArtId":419630,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419688.DA","ArtId":419688,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"419476.DA","ArtId":419476,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421125.DA","ArtId":421125,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417889.JP","ArtId":417889,"Variant":"JP","ExplicitGrpIds":[]},{"AcquisitionFlags":"Event","Type":"ArtStyle","Id":"417868.JP","ArtId":417868,"Variant":"JP","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417340.DA","ArtId":417340,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421130.DA","ArtId":421130,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"419511.DA","ArtId":419511,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421133.DA","ArtId":421133,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417319.DA","ArtId":417319,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421180.DA","ArtId":421180,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421284.DA","ArtId":421284,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421132.DA","ArtId":421132,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421237.DA","ArtId":421237,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421114.DA","ArtId":421114,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421162.DA","ArtId":421162,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417065.DA","ArtId":417065,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421259.DA","ArtId":421259,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417343.DA","ArtId":417343,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421343.DA","ArtId":421343,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417314.DA","ArtId":417314,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417066.DA","ArtId":417066,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421159.DA","ArtId":421159,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417063.DA","ArtId":417063,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421346.DA","ArtId":421346,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417332.DA","ArtId":417332,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421297.DA","ArtId":421297,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417361.DA","ArtId":417361,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421121.DA","ArtId":421121,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421170.DA","ArtId":421170,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421342.DA","ArtId":421342,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421212.DA","ArtId":421212,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421254.DA","ArtId":421254,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421150.DA","ArtId":421150,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421172.DA","ArtId":421172,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421184.DA","ArtId":421184,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421185.DA","ArtId":421185,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421198.DA","ArtId":421198,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421193.DA","ArtId":421193,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421205.DA","ArtId":421205,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421227.DA","ArtId":421227,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421229.DA","ArtId":421229,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"417351.DA","ArtId":417351,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421242.DA","ArtId":421242,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421263.DA","ArtId":421263,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421270.DA","ArtId":421270,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421273.DA","ArtId":421273,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421282.DA","ArtId":421282,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421344.DA","ArtId":421344,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421283.DA","ArtId":421283,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"421303.DA","ArtId":421303,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422142.DA","ArtId":422142,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422322.DA","ArtId":422322,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"417325.DA","ArtId":417325,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"421142.DA","ArtId":421142,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422152.DA","ArtId":422152,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"422167.DA","ArtId":422167,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"422148.DA","ArtId":422148,"Variant":"DA","ExplicitGrpIds":[]},{"AcquisitionFlags":"SeasonReward","Type":"ArtStyle","Id":"422213.DA","ArtId":422213,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"443063.DA","ArtId":443063,"Variant":"DA","ExplicitGrpIds":[]},{"Type":"ArtStyle","Id":"418126.SCHEMATIC","ArtId":418126,"Variant":"SCHEMATIC","ExplicitGrpIds":[]}],"Avatars":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_ChandraNalaar","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_AjaniGoldmane","Type":"Avatar"},{"Id":"Avatar_Basic_GideonJura","Type":"Avatar"},{"Id":"Avatar_Basic_Teferi","Type":"Avatar"},{"Id":"Avatar_Basic_SarkhanVol","Type":"Avatar"},{"Id":"Avatar_Basic_Tezzeret","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_VivienReid","Type":"Avatar"},{"Id":"Avatar_Basic_NissaRevane","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_LilianaVess","Type":"Avatar"},{"Id":"Avatar_Basic_Karn","Type":"Avatar"},{"Id":"Avatar_Basic_JayaBallard","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_JaceBeleren","Type":"Avatar"},{"Id":"Avatar_Basic_Ellywick_AFR","Type":"Avatar"},{"Id":"Avatar_Basic_Wrenn_MID","Type":"Avatar"},{"AcquisitionFlags":"CodeRedemption","Id":"Avatar_Basic_Sorin_VOW","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Elspeth_MOM","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Ashiok_WAR","Type":"Avatar"},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Avatar_Basic_Kaito_NEO","Type":"Avatar"}],"Pets":[{"Type":"Pet","Id":"AFR_Dragon.Skin1","Name":"AFR_Dragon","Variant":"Skin1"},{"Type":"Pet","Id":"AFR_Dragon.Skin2","Name":"AFR_Dragon","Variant":"Skin2"},{"Type":"Pet","Id":"MID_Geist.Skin1","Name":"MID_Geist","Variant":"Skin1"},{"Type":"Pet","Id":"MID_Geist.Skin2","Name":"MID_Geist","Variant":"Skin2"},{"Type":"Pet","Id":"MID_Geist.Skin3","Name":"MID_Geist","Variant":"Skin3"},{"Type":"Pet","Id":"VOW_Bat.Level1","Name":"VOW_Bat","Variant":"Level1"},{"Type":"Pet","Id":"VOW_Bat.Level2","Name":"VOW_Bat","Variant":"Level2"},{"Type":"Pet","Id":"VOW_Bat.Level3","Name":"VOW_Bat","Variant":"Level3"}],"Sleeves":[{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_Basic_Thunderstorm_Bitterblossom","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418002","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418001","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418003","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418004","Type":"Sleeve"},{"AcquisitionFlags":"CodeRedemption","Id":"CardBack_STX_418005","Type":"Sleeve"},{"Id":"CardBack_AFR_419749","Type":"Sleeve"},{"Id":"CardBack_AFR_419144","Type":"Sleeve"},{"Id":"CardBack_AFR_419111","Type":"Sleeve"},{"Id":"CardBack_MID_424253","Type":"Sleeve"},{"Id":"CardBack_MID_423524","Type":"Sleeve"},{"Id":"CardBack_ZNR_402686","Type":"Sleeve"},{"Id":"CardBack_MID_422493","Type":"Sleeve"},{"Id":"CardBack_VOW_424637","Type":"Sleeve"},{"Id":"CardBack_VOW_422028","Type":"Sleeve"},{"Id":"CardBack_VOW_422180","Type":"Sleeve"},{"Id":"CardBack_VOW_421278","Type":"Sleeve"},{"Id":"CardBack_VOW_421349","Type":"Sleeve"},{"AcquisitionFlags":"Event, CodeRedemption","Id":"CardBack_DvC_409074","Type":"Sleeve"},{"Id":"CardBack_DG_MemorialSleeve","Type":"Sleeve"}],"Emotes":[{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Hello","Type":"Emote","Category":"Greeting","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Nice_Thanks","Type":"Emote","FlipType":"Reply","Category":"Kudos","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Thinking_YourGo","Type":"Emote","FlipType":"Priority","Category":"Priority","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_Oops_Sorry","Type":"Emote","FlipType":"Reply","Category":"Accident","Treatment":""},{"AcquisitionFlags":"DefaultLoginGrant","Id":"Phrase_Basic_GoodGame","Type":"Emote","Category":"GoodGame","Treatment":""}],"Titles":[]}}}'
     )
 ]
 
 ARENA_OPEN_TEST_ENTRIES = [
-    ("Unknown Event Start 1",
-    EventResults(new_event=False,
-                 data_update=False,
-                 current_set="",
-                 current_event="",
-                 current_pack=0,
-                 current_pick=0,
-                 picks=[],
-                 pack=[],
-                 card_pool=[],
-                 missing=[]),
-    r'[UnityCrossThreadLogger]==> EventJoin {"id":"57d3b2c6-71ef-44ee-a395-1e977fcdd6b6","request":"{\"EventName\":\"ArenaOpen_Day_Bo1_20240622\",\"EntryCurrencyType\":\"Gem\",\"EntryCurrencyPaid\":1500,\"CustomTokenId\":null}"}'
+    (
+        "Unknown Event Start 1",
+        EventResults(
+            new_event=False,
+            data_update=False,
+            current_set="",
+            current_event="",
+            current_pack=0,
+            current_pick=0,
+            picks=[],
+            pack=[],
+            card_pool=[],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]==> Event_Join {"id":"57d3b2c6-71ef-44ee-a395-1e977fcdd6b6","request":"{\"EventName\":\"ArenaOpen_Day_Bo1_20240622\",\"EntryCurrencyType\":\"Gem\",\"EntryCurrencyPaid\":1500,\"CustomTokenId\":null}"}'
     ),
-    ("Unknown Event Start 2",
-    EventResults(new_event=False,
-                 data_update=False,
-                 current_set="",
-                 current_event="",
-                 current_pack=0,
-                 current_pick=0,
-                 picks=[],
-                 pack=[],
-                 card_pool=[],
-                 missing=[]),
-    r'[UnityCrossThreadLogger]==> EventJoin {"id":"57d3b2c6-71ef-44ee-a395-1e977fcdd6b6","request":"{\"EventName\":\"arenaopen_Day1_Bo1_20240622\",\"EntryCurrencyType\":\"Gem\",\"EntryCurrencyPaid\":1500,\"CustomTokenId\":null}"}'
+    (
+        "Unknown Event Start 2",
+        EventResults(
+            new_event=False,
+            data_update=False,
+            current_set="",
+            current_event="",
+            current_pack=0,
+            current_pick=0,
+            picks=[],
+            pack=[],
+            card_pool=[],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]==> Event_Join {"id":"57d3b2c6-71ef-44ee-a395-1e977fcdd6b6","request":"{\"EventName\":\"arenaopen_Day1_Bo1_20240622\",\"EntryCurrencyType\":\"Gem\",\"EntryCurrencyPaid\":1500,\"CustomTokenId\":null}"}'
     ),
-    ("Day1 Event Start",
-    EventResults(new_event=True,
-                 data_update=False,
-                 current_set="MH3",
-                 current_event="OpenDay1",
-                 current_pack=0,
-                 current_pick=0,
-                 picks=[],
-                 pack=[],
-                 card_pool=[],
-                 missing=[]),
-    r'[UnityCrossThreadLogger]==> EventJoin {"id":"57d3b2c6-71ef-44ee-a395-1e977fcdd6b6","request":"{\"EventName\":\"ArenaOpen_Day1_Bo1_20240622\",\"EntryCurrencyType\":\"Gem\",\"EntryCurrencyPaid\":1500,\"CustomTokenId\":null}"}'
+    (
+        "Day1 Event Start",
+        EventResults(
+            new_event=True,
+            data_update=False,
+            current_set="MH3",
+            current_event="OpenDay1",
+            current_pack=0,
+            current_pick=0,
+            picks=[],
+            pack=[],
+            card_pool=[],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]==> Event_Join {"id":"57d3b2c6-71ef-44ee-a395-1e977fcdd6b6","request":"{\"EventName\":\"ArenaOpen_Day1_Bo1_20240622\",\"EntryCurrencyType\":\"Gem\",\"EntryCurrencyPaid\":1500,\"CustomTokenId\":null}"}'
     ),
-    ("Day2 Event Start",
-    EventResults(new_event=True,
-                 data_update=False,
-                 current_set="OTJ",
-                 current_event="OpenDay2",
-                 current_pack=0,
-                 current_pick=0,
-                 picks=[],
-                 pack=[],
-                 card_pool=[],
-                 missing=[]),
-    r'[UnityCrossThreadLogger]==> EventJoin {"id":"57d3b2c6-71ef-44ee-a395-1e977fcdd6b6","request":"{\"EventName\":\"ArenaOpen_Day2_DraftOne_20240623\",\"EntryCurrencyType\":\"Gem\",\"EntryCurrencyPaid\":1500,\"CustomTokenId\":null}"}'
+    (
+        "Day2 Event Start",
+        EventResults(
+            new_event=True,
+            data_update=False,
+            current_set="OTJ",
+            current_event="OpenDay2",
+            current_pack=0,
+            current_pick=0,
+            picks=[],
+            pack=[],
+            card_pool=[],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]==> Event_Join {"id":"57d3b2c6-71ef-44ee-a395-1e977fcdd6b6","request":"{\"EventName\":\"ArenaOpen_Day2_DraftOne_20240623\",\"EntryCurrencyType\":\"Gem\",\"EntryCurrencyPaid\":1500,\"CustomTokenId\":null}"}'
     ),
-    ("Qualifier Event Start",
-    EventResults(new_event=True,
-                 data_update=False,
-                 current_set="MKM",
-                 current_event="QualSealed",
-                 current_pack=0,
-                 current_pick=0,
-                 picks=[],
-                 pack=[],
-                 card_pool=[],
-                 missing=[]),
-    r'[UnityCrossThreadLogger]==> EventJoin {"id":"57d3b2c6-71ef-44ee-a395-1e977fcdd6b6","request":"{\"EventName\":\"QualifierPlayIn_Bo1_MH3_20240707\",\"EntryCurrencyType\":\"Gem\",\"EntryCurrencyPaid\":1500,\"CustomTokenId\":null}"}'
+    (
+        "Qualifier Event Start",
+        EventResults(
+            new_event=True,
+            data_update=False,
+            current_set="MKM",
+            current_event="QualSealed",
+            current_pack=0,
+            current_pick=0,
+            picks=[],
+            pack=[],
+            card_pool=[],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]==> Event_Join {"id":"57d3b2c6-71ef-44ee-a395-1e977fcdd6b6","request":"{\"EventName\":\"QualifierPlayIn_Bo1_MH3_20240707\",\"EntryCurrencyType\":\"Gem\",\"EntryCurrencyPaid\":1500,\"CustomTokenId\":null}"}'
     ),
-    ("Arena Direct Event Start",
-    EventResults(new_event=True,
-                 data_update=False,
-                 current_set="OTJ",
-                 current_event="Sealed",
-                 current_pack=0,
-                 current_pick=0,
-                 picks=[],
-                 pack=[],
-                 card_pool=[],
-                 missing=[]),
-    r'[UnityCrossThreadLogger]==> EventJoin {"id":"57d3b2c6-71ef-44ee-a395-1e977fcdd6b6","request":"{\"EventName\":\"ArenaDirect_OTJ_Sealed_20240726\",\"EntryCurrencyType\":\"Gem\",\"EntryCurrencyPaid\":1500,\"CustomTokenId\":null}"}'
+    (
+        "Arena Direct Event Start",
+        EventResults(
+            new_event=True,
+            data_update=False,
+            current_set="OTJ",
+            current_event="Sealed",
+            current_pack=0,
+            current_pick=0,
+            picks=[],
+            pack=[],
+            card_pool=[],
+            missing=[]
+        ),
+        r'[UnityCrossThreadLogger]==> Event_Join {"id":"57d3b2c6-71ef-44ee-a395-1e977fcdd6b6","request":"{\"EventName\":\"ArenaDirect_OTJ_Sealed_20240726\",\"EntryCurrencyType\":\"Gem\",\"EntryCurrencyPaid\":1500,\"CustomTokenId\":null}"}'
     ),
-    
-    
 ]
 
 @pytest.fixture(name="session_scanner",scope="session")
@@ -643,6 +872,17 @@ def event_test_cases(input_scanner, event_label, entry_label, expected, entry_st
     # Verify that the OCR method wasn't called
     assert mock_ocr.call_count == 0, f"Test Failed: OCR Check, Set: {event_label}, {entry_label}, Expected: 0, Actual: {mock_ocr.call_count}"
 
+@pytest.mark.parametrize("entry_label, expected, entry_string", TDM_PREMIER_DRAFT_ENTRIES_2025_4_8)
+def test_tdm_premier_draft_new(session_scanner, entry_label, expected, entry_string):
+    """
+    Verify that the new premier draft entries can be processed
+    """
+    with (
+        patch("src.log_scanner.OCR.get_pack") as mock_ocr,
+        patch("src.log_scanner.capture_screen_base64str")
+    ):
+        event_test_cases(session_scanner, "New TDM PremierDraft", entry_label, expected, entry_string, mock_ocr)
+
 @pytest.mark.parametrize("entry_label, expected, entry_string", OTJ_PREMIER_DRAFT_ENTRIES_2024_5_7)
 def test_otj_premier_draft_new(session_scanner, entry_label, expected, entry_string):
     """
@@ -664,6 +904,17 @@ def test_mkm_premier_draft_old(session_scanner, entry_label, expected, entry_str
         patch("src.log_scanner.capture_screen_base64str")
     ):
         event_test_cases(session_scanner, "Old MKM PremierDraft", entry_label, expected, entry_string, mock_ocr)
+
+@pytest.mark.parametrize("entry_label, expected, entry_string", TDM_QUICK_DRAFT_ENTRIES_2025_4_8)
+def test_tdm_quick_draft_new(session_scanner, entry_label, expected, entry_string):
+    """
+    Verify that the new quick draft entries can be processed
+    """
+    with (
+        patch("src.log_scanner.OCR.get_pack") as mock_ocr,
+        patch("src.log_scanner.capture_screen_base64str")
+    ):
+        event_test_cases(session_scanner, "New TDM QuickDraft", entry_label, expected, entry_string, mock_ocr)
 
 @pytest.mark.parametrize("entry_label, expected, entry_string", DMU_QUICK_DRAFT_ENTRIES_2024_5_7)
 def test_dmu_quick_draft_new(session_scanner, entry_label, expected, entry_string):
@@ -712,6 +963,7 @@ def test_arena_open(function_scanner, entry_label, expected, entry_string):
 # TODO - Traditional Sealed
 
 # TODO - Sealed
+
 @pytest.mark.parametrize("entry_label, expected, entry_string", DSK_SEALED_ENTRIES_2024_9_24)
 def test_dsk_sealed(session_scanner, entry_label, expected, entry_string):
     """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,10 +24,10 @@ MOCKED_DATASETS = [
     "OTJ_FakeDraft_All_Data.json",
 ]
 MOCKED_DATASETS_LIST_VALID = [
-    ("MH3", "PremierDraft", "All", "2019-01-01", "2024-07-11", os.path.join(SETS_FOLDER, "MH3_PremierDraft_All_Data.json"), 0),
-    ("MH3", "PremierDraft", "Top", "2019-01-01", "2024-07-11", os.path.join(SETS_FOLDER, "MH3_PremierDraft_Top_Data.json"), 0),
-    ("OTJ", "TradDraft", "Middle", "2019-01-01", "2024-07-11", os.path.join(SETS_FOLDER, "OTJ_TradDraft_Middle_Data.json"), 0),
-    ("OTJ", "QuickDraft", "Bottom", "2019-01-01", "2024-07-11", os.path.join(SETS_FOLDER, "OTJ_QuickDraft_Bottom_Data.json"), 0)
+    ("MH3", "PremierDraft", "All", "2019-01-01", "2024-07-11", 0, os.path.join(SETS_FOLDER, "MH3_PremierDraft_All_Data.json")),
+    ("MH3", "PremierDraft", "Top", "2019-01-01", "2024-07-11", 0, os.path.join(SETS_FOLDER, "MH3_PremierDraft_Top_Data.json")),
+    ("OTJ", "TradDraft", "Middle", "2019-01-01", "2024-07-11", 0, os.path.join(SETS_FOLDER, "OTJ_TradDraft_Middle_Data.json")),
+    ("OTJ", "QuickDraft", "Bottom", "2019-01-01", "2024-07-11", 0, os.path.join(SETS_FOLDER, "OTJ_QuickDraft_Bottom_Data.json"))
 ]
 MOCKED_DATASET_JSON = {
     "meta" : {


### PR DESCRIPTION
FIX: Detect quick drafts that have already started (unrealities/MTGA_Draft_17lands#71)
FEATS:
- Sort the colors of multi-colored cards by WUBRG
- Enable color identity will no longer change the row color of mana fixing cards to gold
- Add "# Games" to the Download Dataset window to help players assess when datasets are large enough for use
- Move all Alchemy sets to the bottom of the set list
- Adjust a few deck suggester parameters to reduce the preference for control decks
- Replace File>Open with File>Read Draft Log, and add File>Read Player.log and File>Open Player.log