### PR TITLE
Persist sorted column across draft picks

### DIFF
--- a/src/ui/components.py
+++ b/src/ui/components.py
@@ -502,6 +502,7 @@ class ModernTreeview(ttk.Treeview):
             parent, columns=columns, show="headings", style="Treeview", **kwargs
         )
         self.column_sort_state = {col: False for col in columns}
+        self.active_sort_col = None  # Tracks the currently sorted column
         self.active_fields = []  # Injected by Manager
         self.base_labels = {}  # Store original names for arrows
         self._setup_headers(columns)
@@ -552,10 +553,14 @@ class ModernTreeview(ttk.Treeview):
         self.tag_configure("high_fit", background="#0c4a6e", foreground="#7dd3fc")
 
     def _handle_sort(self, col):
+        self.column_sort_state[col] = not self.column_sort_state[col]
+        self.active_sort_col = col
+        self._apply_sort(col)
+
+    def _apply_sort(self, col):
         from src.card_logic import field_process_sort
 
-        self.column_sort_state[col] = not self.column_sort_state[col]
-        rev = self.column_sort_state[col]
+        rev = self.column_sort_state.get(col, False)
 
         # Apply the visual arrow to the active column, reset the others
         for c in self["columns"]:

--- a/src/ui/dashboard.py
+++ b/src/ui/dashboard.py
@@ -405,9 +405,14 @@ class DashboardFrame(ttk.Frame):
                 }
             )
 
-        processed_rows.sort(key=lambda x: x["sort_key"], reverse=True)
+        active_col = getattr(tree, "active_sort_col", None)
+        if not active_col:
+            processed_rows.sort(key=lambda x: x["sort_key"], reverse=True)
         for row in processed_rows:
             tree.insert("", "end", values=row["vals"], tags=(row["tag"],))
+
+        if active_col:
+            tree._apply_sort(active_col)
 
     def update_signals(self, scores: Dict[str, float]):
         if self.signal_meter:


### PR DESCRIPTION
When you sort the card table by clicking a column header during a draft, that sort now persists as the pack advances
  to the next pick. Previously, each new pick would reset the table back to the default sort order (by contextual
  score/GIH WR). Now the column you sorted by — and the direction (ascending or descending) — are remembered and
  reapplied whenever the pack data refreshes.