### PR TITLE
Suppress returnable indicator for user-picked cards; add tests

### DIFF
--- a/src/log_scanner.py
+++ b/src/log_scanner.py
@@ -1115,7 +1115,15 @@ class ArenaScanner:
                     # A pack from slot i wheels back at pick (i+1) + rotation_size
                     return_pick = (i + 1) + rotation_size
                     if return_pick > self.current_pick:
-                        for name in self.set_data.get_names_by_id(slot_ids):
+                        picked_from_slot = set(
+                            self.picked_cards[i]
+                            if i < len(self.picked_cards)
+                            else []
+                        )
+                        remaining_ids = [
+                            cid for cid in slot_ids if cid not in picked_from_slot
+                        ]
+                        for name in self.set_data.get_names_by_id(remaining_ids):
                             returnable_picks_by_name.setdefault(name, []).append(
                                 return_pick
                             )

--- a/tests/test_returnable.py
+++ b/tests/test_returnable.py
@@ -1,0 +1,239 @@
+"""
+tests/test_returnable.py
+Unit tests for the wheel/returnable indicator logic in retrieve_current_pack_cards.
+
+In an 8-player draft:
+  pack_index    = (current_pick - 1) % 8
+  return_pick   = (slot_index + 1) + 8
+
+A card in slot i is returnable only if:
+  - return_pick > current_pick
+  - the user did NOT already pick it from slot i
+"""
+
+import pytest
+from src.log_scanner import ArenaScanner
+
+
+@pytest.fixture
+def scanner(tmp_path):
+    """Fresh scanner with retrieve_unknown=True so any string ID is its own card name."""
+    s = ArenaScanner(str(tmp_path / "Player.log"), [], retrieve_unknown=True)
+    s.log_enable(False)
+    return s
+
+
+def _setup(scanner, *, current_pick, current_pack_cards, initial_pack=None, picked_cards=None):
+    """
+    Inject scanner state for returnable tests.
+
+    current_pack_cards  - list of card IDs in the pack the user is currently seeing
+    initial_pack        - dict of {slot_index: [card_ids]} for other slots
+    picked_cards        - dict of {slot_index: [card_ids]} the user has already picked
+    """
+    scanner.current_pick = current_pick
+    pack_index = (current_pick - 1) % 8
+
+    scanner.pack_cards = [[] for _ in range(8)]
+    scanner.pack_cards[pack_index] = list(current_pack_cards)
+
+    scanner.initial_pack = [[] for _ in range(8)]
+    for i, ids in (initial_pack or {}).items():
+        scanner.initial_pack[i] = list(ids)
+
+    scanner.picked_cards = [[] for _ in range(8)]
+    for i, ids in (picked_cards or {}).items():
+        scanner.picked_cards[i] = list(ids)
+
+    scanner.taken_cards = [c for ids in (picked_cards or {}).values() for c in ids]
+
+
+def _returnable(scanner):
+    """Returns {card_name: returnable_at_list} for the current pack."""
+    return {c["name"]: c.get("returnable_at", []) for c in scanner.retrieve_current_pack_cards()}
+
+
+# ---------------------------------------------------------------------------
+# Basic returnable behaviour
+# ---------------------------------------------------------------------------
+
+def test_no_other_slots_means_no_returnable(scanner):
+    """Card in pack with no other initial_pack slots → not returnable."""
+    _setup(scanner, current_pick=2, current_pack_cards=["card_a"])
+    assert _returnable(scanner)["card_a"] == []
+
+
+def test_card_in_future_slot_is_returnable(scanner):
+    """Card appearing in a slot whose return_pick is still ahead → marked returnable."""
+    # pick 2 → pack_index=1.  slot 0 returns at pick 9.
+    _setup(
+        scanner,
+        current_pick=2,
+        current_pack_cards=["card_a"],
+        initial_pack={0: ["card_a", "card_b"]},
+    )
+    assert _returnable(scanner)["card_a"] == [9]
+
+
+def test_card_not_in_other_slot_has_no_returnable(scanner):
+    """Card in pack but absent from all other slots → not returnable."""
+    _setup(
+        scanner,
+        current_pick=2,
+        current_pack_cards=["card_a"],
+        initial_pack={0: ["card_b", "card_c"]},
+    )
+    assert _returnable(scanner)["card_a"] == []
+
+
+# ---------------------------------------------------------------------------
+# User-picked card suppression
+# ---------------------------------------------------------------------------
+
+def test_picked_card_not_returnable(scanner):
+    """
+    Card A picked at pick 1 (slot 0). At pick 2, card A is in the pack.
+    Slot 0 would return at pick 9 — but user already took it, so no ⟳.
+    """
+    _setup(
+        scanner,
+        current_pick=2,
+        current_pack_cards=["card_a"],
+        initial_pack={0: ["card_a", "card_b"]},
+        picked_cards={0: ["card_a"]},
+    )
+    assert _returnable(scanner)["card_a"] == []
+
+
+def test_different_card_picked_from_slot_does_not_suppress(scanner):
+    """
+    User picked card_b from slot 0. Card_a is still in slot 0 → still returnable.
+    """
+    _setup(
+        scanner,
+        current_pick=2,
+        current_pack_cards=["card_a"],
+        initial_pack={0: ["card_a", "card_b"]},
+        picked_cards={0: ["card_b"]},
+    )
+    assert _returnable(scanner)["card_a"] == [9]
+
+
+def test_picked_from_different_slot_does_not_suppress(scanner):
+    """
+    User picked card_a from slot 2 (a different slot). The copy in slot 0 is
+    still there and should still be marked returnable.
+    """
+    # pick 3 → pack_index=2.  slot 0 returns at 9, slot 1 returns at 10.
+    _setup(
+        scanner,
+        current_pick=3,
+        current_pack_cards=["card_a"],
+        initial_pack={0: ["card_a"], 1: ["card_x"]},
+        picked_cards={2: ["card_a"]},   # picked from the current slot, not slot 0
+    )
+    assert _returnable(scanner)["card_a"] == [9]
+
+
+# ---------------------------------------------------------------------------
+# User's concrete example
+# ---------------------------------------------------------------------------
+
+def test_user_example_taken_pick1_no_returnable_at_pick2(scanner):
+    """
+    Card A taken at pick 1 (slot 0). At pick 2, card A appears in the pack.
+    Slot 0 would return at pick 9 — but user already has it → no ⟳.
+    """
+    _setup(
+        scanner,
+        current_pick=2,
+        current_pack_cards=["card_a", "card_b"],
+        initial_pack={0: ["card_a", "card_c"]},
+        picked_cards={0: ["card_a"]},
+    )
+    result = _returnable(scanner)
+    assert result["card_a"] == [], "card_a was picked; should not be returnable"
+    assert result["card_b"] == [], "card_b not in any other slot"
+
+
+def test_user_example_not_taken_pick2_returnable_at_pick3(scanner):
+    """
+    Card A not taken at pick 2 (slot 1). At pick 3, card A appears in the pack.
+    Slot 1 returns at pick 10 — user never took it → ⟳ at pick 10.
+    """
+    _setup(
+        scanner,
+        current_pick=3,
+        current_pack_cards=["card_a", "card_b"],
+        initial_pack={1: ["card_a", "card_c"]},
+        picked_cards={},   # user picked nothing from slot 1
+    )
+    result = _returnable(scanner)
+    assert result["card_a"] == [10], "card_a should be returnable at pick 10"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+def test_return_pick_already_passed_not_returnable(scanner):
+    """Slot whose return_pick <= current_pick is ignored."""
+    # pick 10 → pack_index=1.  slot 0 returns at 9, which is <= 10 → not returnable.
+    _setup(
+        scanner,
+        current_pick=10,
+        current_pack_cards=["card_a"],
+        initial_pack={0: ["card_a"]},
+    )
+    assert _returnable(scanner)["card_a"] == []
+
+
+def test_multiple_returnable_slots(scanner):
+    """Card appearing in two future slots → both return picks listed, sorted."""
+    # pick 1 → pack_index=0.  slot 1 returns at 10, slot 2 returns at 11.
+    _setup(
+        scanner,
+        current_pick=1,
+        current_pack_cards=["card_a"],
+        initial_pack={1: ["card_a"], 2: ["card_a"]},
+    )
+    assert _returnable(scanner)["card_a"] == [10, 11]
+
+
+def test_multiple_returnable_slots_one_picked(scanner):
+    """Card in two future slots but user picked it from one → only the other listed."""
+    _setup(
+        scanner,
+        current_pick=1,
+        current_pack_cards=["card_a"],
+        initial_pack={1: ["card_a"], 2: ["card_a"]},
+        picked_cards={1: ["card_a"]},
+    )
+    assert _returnable(scanner)["card_a"] == [11]
+
+
+def test_current_pack_slot_excluded_from_returnable(scanner):
+    """The slot currently being viewed is never counted as a return source."""
+    # pick 1 → pack_index=0.  initial_pack[0] contains card_a but that's the
+    # current slot — it must not create a spurious returnable entry.
+    _setup(
+        scanner,
+        current_pick=1,
+        current_pack_cards=["card_a"],
+        initial_pack={0: ["card_a"]},   # same slot as pack_index
+    )
+    assert _returnable(scanner)["card_a"] == []
+
+
+def test_unrelated_cards_in_other_slots_not_marked(scanner):
+    """Cards present only in the current pack and not in any other slot → no returnable."""
+    _setup(
+        scanner,
+        current_pick=2,
+        current_pack_cards=["card_a", "card_b", "card_c"],
+        initial_pack={0: ["card_x", "card_y"]},
+    )
+    result = _returnable(scanner)
+    assert result["card_a"] == []
+    assert result["card_b"] == []
+    assert result["card_c"] == []

--- a/tests/test_sort_persistence.py
+++ b/tests/test_sort_persistence.py
@@ -1,0 +1,315 @@
+"""
+tests/test_sort_persistence.py
+Tests for the persistent column sort feature in ModernTreeview.
+
+Covers:
+  - active_sort_column tracking
+  - config persistence (table_sort_states)
+  - sort group mapping (pack_table / overlay_table share state)
+  - reapply_sort() after data reload
+  - cross-table sort inheritance via shared config
+  - force_reverse parameter
+  - sort arrow heading indicators
+  - graceful no-op when saved column no longer exists
+"""
+
+import pytest
+import tkinter
+from types import SimpleNamespace
+from unittest.mock import patch
+from src.ui.components import ModernTreeview
+from src.ui.styles import Theme
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_config(sort_states=None):
+    """Returns a minimal config object with optional pre-populated sort states."""
+    settings = SimpleNamespace()
+    if sort_states is not None:
+        settings.table_sort_states = dict(sort_states)
+    # No table_sort_states attribute → tests hasattr() branch in __init__/_handle_sort
+    config = SimpleNamespace(settings=settings)
+    return config
+
+
+WRITE_CFG = "src.configuration.write_configuration"
+
+
+def make_tree(root, columns=("name", "gihwr", "value"), view_id=None, config=None):
+    """Convenience factory. __init__ never calls write_configuration, so no patch needed."""
+    tree = ModernTreeview(root, columns=columns, view_id=view_id, config=config)
+    tree.active_fields = list(columns)
+    return tree
+
+
+def get_col_values(tree, col_index=0):
+    return [tree.item(k)["values"][col_index] for k in tree.get_children()]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def root():
+    r = tkinter.Tk()
+    Theme.apply(r, "Dark")
+    yield r
+    r.destroy()
+
+
+# ---------------------------------------------------------------------------
+# active_sort_column tracking
+# ---------------------------------------------------------------------------
+
+class TestActiveSortColumn:
+    def test_initially_none(self, root):
+        tree = make_tree(root)
+        assert tree.active_sort_column is None
+
+    def test_set_after_sort(self, root):
+        tree = make_tree(root)
+        tree.insert("", "end", values=("Lightning Bolt", "60.0", "80"))
+        with patch(WRITE_CFG):
+            tree._handle_sort("gihwr")
+        assert tree.active_sort_column == "gihwr"
+
+    def test_updates_to_most_recently_sorted_column(self, root):
+        tree = make_tree(root)
+        tree.insert("", "end", values=("Card A", "55.0", "70"))
+        with patch(WRITE_CFG):
+            tree._handle_sort("gihwr")
+            tree._handle_sort("value")
+        assert tree.active_sort_column == "value"
+
+    def test_loaded_from_config_on_init(self, root):
+        # pack_table → sort_group="pack"; init loads if both config and view_id are set
+        config = make_config(sort_states={"pack": {"column": "gihwr", "reverse": True}})
+        tree = make_tree(root, view_id="pack_table", config=config)
+        assert tree.active_sort_column == "gihwr"
+        assert tree.column_sort_state["gihwr"] is True
+
+
+# ---------------------------------------------------------------------------
+# Config persistence
+# ---------------------------------------------------------------------------
+
+class TestConfigPersistence:
+    def test_sort_state_written_to_config(self, root):
+        config = make_config()
+        tree = make_tree(root, view_id="pack_table", config=config)
+        tree.insert("", "end", values=("Card A", "60.0", "80"))
+
+        with patch(WRITE_CFG) as mock_write:
+            tree._handle_sort("gihwr")
+            mock_write.assert_called_once()
+
+        assert hasattr(config.settings, "table_sort_states")
+        state = config.settings.table_sort_states["pack"]
+        assert state["column"] == "gihwr"
+        assert state["reverse"] is True  # first click → descending
+
+    def test_sort_direction_toggled_and_persisted(self, root):
+        config = make_config()
+        tree = make_tree(root, view_id="pack_table", config=config)
+        tree.insert("", "end", values=("Card A", "60.0", "80"))
+
+        with patch(WRITE_CFG):
+            tree._handle_sort("gihwr")   # descending
+            assert config.settings.table_sort_states["pack"]["reverse"] is True
+
+            tree._handle_sort("gihwr")   # ascending
+            assert config.settings.table_sort_states["pack"]["reverse"] is False
+
+    def test_no_config_does_not_crash(self, root):
+        """Tree without config sorts fine; just nothing persisted."""
+        tree = make_tree(root, view_id=None, config=None)
+        tree.insert("", "end", values=("Card A", "60.0", "80"))
+        tree.insert("", "end", values=("Card B", "40.0", "50"))
+        tree._handle_sort("gihwr")
+        assert tree.active_sort_column == "gihwr"
+
+    def test_write_configuration_called_with_config_object(self, root):
+        config = make_config()
+        tree = make_tree(root, view_id="pack_table", config=config)
+        tree.insert("", "end", values=("Card A", "60.0", "80"))
+
+        with patch(WRITE_CFG) as mock_write:
+            tree._handle_sort("gihwr")
+            args, _ = mock_write.call_args
+            assert args[0] is config
+
+
+# ---------------------------------------------------------------------------
+# Sort group mapping
+# ---------------------------------------------------------------------------
+
+class TestSortGroupMapping:
+    @pytest.mark.parametrize("view_id,expected_group", [
+        ("pack_table",         "pack"),
+        ("overlay_table",      "pack"),
+        ("taken_table",        "pool"),
+        ("overlay_pool_table", "pool"),
+        ("missing_table",      "missing_table"),
+        (None,                 "default"),
+    ])
+    def test_sort_group_values(self, root, view_id, expected_group):
+        tree = make_tree(root, view_id=view_id)
+        assert tree.sort_group == expected_group
+
+    def test_pack_and_overlay_share_sort_state(self, root):
+        """Sorting pack_table should be visible to overlay_table via shared config."""
+        config = make_config()
+
+        pack_tree = make_tree(root, view_id="pack_table", config=config)
+        pack_tree.insert("", "end", values=("Card A", "60.0", "80"))
+        with patch(WRITE_CFG):
+            pack_tree._handle_sort("gihwr")
+
+        # overlay_table reads the same "pack" group
+        assert config.settings.table_sort_states["pack"]["column"] == "gihwr"
+
+        overlay_tree = make_tree(root, view_id="overlay_table", config=config)
+        overlay_tree.insert("", "end", values=("Card A", "60.0", "80"))
+        assert overlay_tree.active_sort_column == "gihwr"
+
+
+# ---------------------------------------------------------------------------
+# reapply_sort()
+# ---------------------------------------------------------------------------
+
+class TestReapplySort:
+    def test_reapply_restores_order_after_reload(self, root):
+        """Simulate a new pick: delete rows, re-insert shuffled, call reapply_sort."""
+        tree = make_tree(root, view_id="pack_table", config=make_config())
+
+        def populate(rows):
+            for item in tree.get_children():
+                tree.delete(item)
+            for row in rows:
+                tree.insert("", "end", values=row)
+
+        # Sort descending by gihwr
+        populate([("Card A", "40.0", "50"), ("Card B", "70.0", "90")])
+        with patch(WRITE_CFG):
+            tree._handle_sort("gihwr")
+
+        assert get_col_values(tree, 1)[0] == "70.0"
+
+        # New pick: reload rows in different order
+        populate([("Card C", "30.0", "40"), ("Card D", "80.0", "95")])
+        with patch(WRITE_CFG):
+            tree.reapply_sort()
+
+        assert get_col_values(tree, 1)[0] == "80.0"
+
+    def test_reapply_returns_true_when_sort_applied(self, root):
+        config = make_config()
+        tree = make_tree(root, view_id="pack_table", config=config)
+        tree.insert("", "end", values=("Card A", "60.0", "80"))
+        with patch(WRITE_CFG):
+            tree._handle_sort("gihwr")
+            result = tree.reapply_sort()
+        assert result is True
+
+    def test_reapply_returns_false_with_no_active_sort(self, root):
+        tree = make_tree(root, view_id="pack_table", config=make_config())
+        tree.insert("", "end", values=("Card A", "60.0", "80"))
+        assert tree.reapply_sort() is False
+
+    def test_reapply_returns_false_when_saved_column_missing(self, root):
+        """Config references a column not present in this table → graceful no-op."""
+        config = make_config(sort_states={"pack": {"column": "nonexistent_col", "reverse": True}})
+        tree = make_tree(root, view_id="pack_table", config=config)
+        tree.insert("", "end", values=("Card A", "60.0", "80"))
+        result = tree.reapply_sort()
+        assert result is False
+
+    def test_reapply_inherits_sort_from_sibling_table(self, root):
+        """overlay_table reapply_sort() picks up sort set by pack_table."""
+        config = make_config()
+
+        pack_tree = make_tree(root, view_id="pack_table", config=config)
+        pack_tree.insert("", "end", values=("Card A", "40.0", "50"))
+        pack_tree.insert("", "end", values=("Card B", "70.0", "90"))
+        with patch(WRITE_CFG):
+            pack_tree._handle_sort("gihwr")
+
+        overlay_tree = make_tree(root, view_id="overlay_table", config=config)
+        overlay_tree.insert("", "end", values=("Card C", "30.0", "40"))
+        overlay_tree.insert("", "end", values=("Card D", "80.0", "95"))
+        with patch(WRITE_CFG):
+            overlay_tree.reapply_sort()
+
+        assert get_col_values(overlay_tree, 1)[0] == "80.0"
+
+
+# ---------------------------------------------------------------------------
+# force_reverse parameter
+# ---------------------------------------------------------------------------
+
+class TestForceReverse:
+    def test_force_reverse_true_does_not_toggle(self, root):
+        tree = make_tree(root)
+        tree.insert("", "end", values=("Card A", "40.0", "50"))
+        tree.insert("", "end", values=("Card B", "70.0", "90"))
+
+        # Force descending without toggling
+        tree._handle_sort("gihwr", force_reverse=True)
+        assert tree.column_sort_state["gihwr"] is True
+        assert get_col_values(tree, 1)[0] == "70.0"
+
+    def test_force_reverse_false_gives_ascending(self, root):
+        tree = make_tree(root)
+        tree.insert("", "end", values=("Card A", "40.0", "50"))
+        tree.insert("", "end", values=("Card B", "70.0", "90"))
+
+        tree._handle_sort("gihwr", force_reverse=False)
+        assert tree.column_sort_state["gihwr"] is False
+        assert get_col_values(tree, 1)[0] == "40.0"
+
+    def test_force_reverse_does_not_change_existing_state_of_other_columns(self, root):
+        tree = make_tree(root)
+        tree.insert("", "end", values=("Card A", "40.0", "50"))
+
+        tree._handle_sort("gihwr", force_reverse=True)
+        # value column was never touched
+        assert tree.column_sort_state["value"] is False
+
+
+# ---------------------------------------------------------------------------
+# Sort arrow heading indicators
+# ---------------------------------------------------------------------------
+
+class TestSortArrowIndicators:
+    def test_arrow_shown_on_active_column_descending(self, root):
+        tree = make_tree(root)
+        tree.insert("", "end", values=("Card A", "60.0", "80"))
+        tree._handle_sort("gihwr")
+        heading_text = tree.heading("gihwr")["text"]
+        assert "▼" in heading_text
+
+    def test_arrow_shown_on_active_column_ascending(self, root):
+        tree = make_tree(root)
+        tree.insert("", "end", values=("Card A", "60.0", "80"))
+        tree._handle_sort("gihwr")  # descending
+        tree._handle_sort("gihwr")  # ascending
+        heading_text = tree.heading("gihwr")["text"]
+        assert "▲" in heading_text
+
+    def test_arrow_cleared_from_previously_sorted_column(self, root):
+        tree = make_tree(root)
+        tree.insert("", "end", values=("Card A", "60.0", "80"))
+        tree._handle_sort("gihwr")
+        tree._handle_sort("value")
+        assert "▼" not in tree.heading("gihwr")["text"]
+        assert "▲" not in tree.heading("gihwr")["text"]
+
+    def test_arrow_shown_on_init_when_sort_state_loaded(self, root):
+        """If config already has a sort state, the arrow should be present from the start."""
+        config = make_config(sort_states={"pack": {"column": "gihwr", "reverse": True}})
+        tree = make_tree(root, view_id="pack_table", config=config)
+        assert "▼" in tree.heading("gihwr")["text"]


### PR DESCRIPTION
Cards already picked by the user from a wheeling slot are excluded from the returnable_at calculation. Also adds test suites for both the returnable logic and the persistent column sort feature.