### PR TITLE
v4.18: update URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The application is structured into a collapsible Live Dashboard and several func
 - **Sidebar:** Contains visual "Open Lane" Signal detection, your current Mana Curve, and your Pool Balance (Creatures/Spells/Lands). You can click on the headers of these panels to collapse them.
 
 ### Application Tabs
-- **Datasets:** Manage, download, and update 17Lands card data locally. Provides detailed download summaries, including exactly how many MTGA cards were successfully matched with 17Lands telemetry data.
+- **Datasets:** Manage, download, and update 17Lands card data locally. Provides detailed download summaries, including exactly how many MTGA cards were successfully matched with 17Lands telemetry data. Choose a **Time Period** (All Time, Latest Event, Last Week, etc.) to match 17Lands, and use **Clear Set History** to delete old downloaded datasets and re-sync a clean copy if loading slows down.
 - **Card Pool:** View the cards you have drafted. Features a **"Switch to Visual View"** button to stack your cards into mana curve columns exactly like MTG Arena does.
 - **Deck Builder:** A fully interactive deck construction environment combining Auto-Generation and manual Custom building. Features a 1-click **Auto-Lands** button, a sleek basics toolbar, and live deck size validation.
 - **Comparisons:** Search and add multiple cards to directly compare their stats side-by-side.

--- a/builder/Installer.iss
+++ b/builder/Installer.iss
@@ -1,7 +1,7 @@
 ; -- MtgaDraft.iss --
 [Setup]
 AppName=MTGA Draft Tool
-AppVersion=4.17
+AppVersion=4.18
 WizardStyle=modern
 DefaultDirName={sd}\MtgaDraftTool
 DefaultGroupName=MtgaDraftTool
@@ -11,7 +11,7 @@ Compression=lzma2
 UsePreviousAppDir=yes
 SolidCompression=yes
 OutputDir={app}
-OutputBaseFilename=MTGA_Draft_Tool_V0417
+OutputBaseFilename=MTGA_Draft_Tool_V0418
 InfoAfterFile=..\release_notes.txt
 [Files]
 Source: "..\dist\MTGA_Draft_Tool.exe"; DestDir: "{app}"

--- a/docs/superpowers/specs/2026-07-08-17lands-api-card-data-migration-design.md
+++ b/docs/superpowers/specs/2026-07-08-17lands-api-card-data-migration-design.md
@@ -1,0 +1,62 @@
+# 17Lands `/api/card_data` Migration — Design
+
+**Date:** 2026-07-08
+**Branch:** 418
+
+## Problem
+
+The ETL pipeline and desktop client fetch card ratings from
+`https://www.17lands.com/card_ratings/data`. 17Lands rebuilt their card data
+page and moved the JSON API to `/api/card_data`. The old route still returns
+HTTP 200 but is a degraded shim:
+
+- Ignores `colors` — responses with and without `colors=WU` are byte-identical,
+  so every archetype in the ETL output was a copy of "All Decks" (caught by
+  `server/validate.py`).
+- Ignores `time_period` — always serves a small stale snapshot (~2.5K games for
+  MSH's most-played card vs ~63K from the real endpoint).
+- Nulls out win-rate fields such as `opening_hand_win_rate` (caused the
+  TradSealed "0% win rate despite non-zero samples" validation error).
+
+## API changes to absorb
+
+1. Endpoint: `/card_ratings/data` → `/api/card_data` (still on www.17lands.com;
+   api.17lands.com remains a different, unsuitable host).
+2. Query param rename: `format` → `event_type`.
+3. Response shape: bare JSON array → `{"copyright": ..., "notes": ...,
+   "data": [...]}`. Card objects inside `data` are unchanged.
+
+`/color_ratings/data` (client + ETL) is unaffected — the new frontend still
+calls it with `event_type`, and live requests return correct data.
+
+## Changes
+
+| Location | Change |
+|---|---|
+| `src/seventeenlands.py:_fetch_archetype_with_cache` | New URL + `event_type` param + unwrap `data` |
+| `src/seventeenlands.py:download_card_ratings` | Same |
+| `src/seventeenlands.py:build_card_ratings_url` | Same (test-only helper) |
+| `server/extract.py:extract_17lands_data` | Same; refresh the stale endpoint comment |
+
+Supporting changes:
+
+- **Cache buster:** raw-cache filenames in `Temp/RawCache` gain a `_v2` marker
+  so degraded responses cached in the last 12 hours are not reused. The cache
+  keeps storing the unwrapped card array.
+- **Defensive unwrap:** accept both a dict payload (`payload["data"]`) and a
+  bare list, so older cached arrays and any future un-wrapping keep parsing.
+- **Tests:** update mocked URLs and payload shapes in
+  `tests/test_seventeenlands.py` and `tests/server/test_extract.py`.
+
+## Rejected alternative
+
+Fallback to the old endpoint on failure: rejected because the old endpoint
+fails by returning *misleading* data, not errors — a fallback would silently
+reintroduce the corruption the validator just caught. Fail loudly instead.
+
+## Verification
+
+1. Updated unit tests pass (test-first).
+2. Live spot-check: MSH PremierDraft `colors=WU` differs from All Decks and
+   game counts are full-population.
+3. Full ETL run regenerates MSH datasets with validation passing.

--- a/main.py
+++ b/main.py
@@ -64,7 +64,7 @@ def load_data(args, config, progress_callback):
             if len(msg) > 75:
                 msg = msg[:72] + "..."
             progress_callback(msg)
-            
+
     splash_handler = SplashLogHandler()
     splash_handler.setLevel(logging.INFO)
     logging.getLogger().addHandler(splash_handler)
@@ -92,13 +92,35 @@ def load_data(args, config, progress_callback):
         if db_loc and os.path.exists(os.path.join(db_loc, "Downloads", "Raw")):
             pass
         else:
-            db_loc = args.data or (retrieve_arena_directory(log_path) if log_path else None)
+            db_loc = args.data or (
+                retrieve_arena_directory(log_path) if log_path else None
+            )
             if db_loc:
                 config.settings.database_location = db_loc
                 write_configuration(config)
 
         # 3. SYNC OFFICIAL DATASETS
-        if config.settings.auto_sync_datasets:
+        upgraded = config.settings.last_run_version != constants.APPLICATION_VERSION
+        if upgraded:
+            # One-time migration after an update. v4.18 corrects 17Lands stats
+            # that were previously limited to a single day of data, so force a
+            # refresh even if auto-sync is off and clear the now-orphaned raw
+            # cache (keyed by the retired start_date/end_date scheme).
+            progress_callback("Applying corrected 17Lands data (one-time update)...")
+            try:
+                from src.utils import purge_raw_cache
+
+                purge_raw_cache()
+            except Exception as purge_e:
+                logger.debug(f"Raw cache purge skipped (non-fatal): {purge_e}")
+
+            from src.dataset_updater import DatasetUpdater
+
+            DatasetUpdater(config).sync_datasets(progress_callback)
+
+            config.settings.last_run_version = constants.APPLICATION_VERSION
+            write_configuration(config)
+        elif config.settings.auto_sync_datasets:
             from src.dataset_updater import DatasetUpdater
 
             updater = DatasetUpdater(config)
@@ -164,7 +186,9 @@ def load_data(args, config, progress_callback):
                 if os.path.exists(constants.DRAFT_LOG_FOLDER):
                     for f in os.listdir(constants.DRAFT_LOG_FOLDER):
                         if f.startswith("DraftLog_") and f.endswith(".log"):
-                            past_logs.append(os.path.join(constants.DRAFT_LOG_FOLDER, f))
+                            past_logs.append(
+                                os.path.join(constants.DRAFT_LOG_FOLDER, f)
+                            )
 
                 if past_logs:
                     past_logs.sort(key=os.path.getmtime, reverse=True)
@@ -278,10 +302,10 @@ def main():
 
         # Launch non-blocking Splash
         SplashWindow(
-            root, 
-            task=lambda cb: load_data(args, config, cb), 
+            root,
+            task=lambda cb: load_data(args, config, cb),
             on_complete=on_ready,
-            show_ui=getattr(config.settings, "show_splash_screen", True)
+            show_ui=getattr(config.settings, "show_splash_screen", True),
         )
 
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mtga-draft-tool"
-version = "4.17"
+version = "4.18"
 description = "Magic: The Gathering Arena draft tool that utilizes 17Lands data."
 authors = ["unrealities"]
 readme = "README.md"

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,5 +1,6 @@
 ===================== RELEASE NOTES 4.18 =====================
 * unrealities: [Bug] Fixed a major issue where 17Lands card and color statistics only reflected the most recent day of data (e.g. ~500 games instead of the full set). The tool now requests the correct "All Time" period, matching the numbers shown on 17Lands.
+* unrealities: [Bug] Migrated card statistics to 17Lands' new `/api/card_data` endpoint. The retired endpoint had stopped honoring the color archetype and time period filters, which made every archetype display identical "All Decks" numbers and left win rates empty in some formats.
 * unrealities: [UX/UI] The dataset download screen now offers a Time Period drop-down (All Time, Latest Event, Last Week, etc.) in place of manual start/end dates, mirroring 17Lands.
 * unrealities: [UX/UI] On first launch after updating, the app performs a one-time refresh of the corrected 17Lands datasets and clears the stale local cache automatically.
 

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,3 +1,8 @@
+===================== RELEASE NOTES 4.18 =====================
+* unrealities: [Bug] Fixed a major issue where 17Lands card and color statistics only reflected the most recent day of data (e.g. ~500 games instead of the full set). The tool now requests the correct "All Time" period, matching the numbers shown on 17Lands.
+* unrealities: [UX/UI] The dataset download screen now offers a Time Period drop-down (All Time, Latest Event, Last Week, etc.) in place of manual start/end dates, mirroring 17Lands.
+* unrealities: [UX/UI] On first launch after updating, the app performs a one-time refresh of the corrected 17Lands datasets and clears the stale local cache automatically.
+
 ===================== RELEASE NOTES 4.17 =====================
 * unrealities: [Feature] Added a toggle in Preferences to completely disable the Splash Screen on startup for users who prefer a silent background load (#179).
 * unrealities: [Bug] Fixed an issue where card tooltips failed to download artwork due to new Scryfall API security requirements rejecting requests without User-Agent headers (#182).

--- a/server/config.py
+++ b/server/config.py
@@ -26,6 +26,28 @@ WAF_COOLDOWN_SEC = 180.0  # 3 minutes of sleep if we get a 403/WAF block
 # Statistical Thresholds
 MIN_GAMES_THRESHOLD = 500  # Increased to reduce API spam and filter out noisy data
 
+# --- 17LANDS TIME PERIODS ---
+# 17Lands dropped custom start_date/end_date ranges in favour of these preset
+# "time_period" values (the drop-down on the card pages). These strings are the
+# query values sent by the site; confirm against the browser Network tab if a
+# preset ever stops returning data.
+TIME_PERIOD_ALL_TIME = "ALL_TIME"
+TIME_PERIOD_ALL_EXCEPT_FIRST_WEEK = "ALL_EXCEPT_FIRST_WEEK"
+TIME_PERIOD_LATEST_EVENT = "LATEST_EVENT"
+TIME_PERIOD_LAST_TWO_WEEKS = "LAST_TWO_WEEKS"
+TIME_PERIOD_LAST_WEEK = "LAST_WEEK"
+TIME_PERIOD_LAST_DAY = "LAST_DAY"
+TIME_PERIOD_FIRST_WEEK = "FIRST_WEEK"
+
+
+def default_time_period(set_code: str) -> str:
+    """The ETL pulls full history for standard sets, but Cube runs are distinct
+    short-lived events, so we take the latest event to avoid blending them."""
+    if "CUBE" in set_code.upper():
+        return TIME_PERIOD_LATEST_EVENT
+    return TIME_PERIOD_ALL_TIME
+
+
 # Data-quality validation. A brand-new set can legitimately look thin on day
 # one/two (few games, sparse archetypes), so validation only *blocks* a publish
 # once the set has at least this many days of data. Below that, issues are logged

--- a/server/extract.py
+++ b/server/extract.py
@@ -184,13 +184,12 @@ def extract_17lands_data(
     time_period: str,
 ) -> dict:
     archetype_data = {}
-    # NOTE: Must use www.17lands.com (not api.17lands.com). The api host serves a
-    # limited default snapshot that collapses every archetype into a tiny sample.
-    #
-    # 17Lands replaced start_date/end_date ranges with a `time_period` preset
-    # (the site's drop-down). Without it the endpoint defaults to LAST_DAY, which
-    # is why we were seeing a single day of data. See config.TIME_PERIOD_*.
-    base_url = "https://www.17lands.com/card_ratings/data"
+    # NOTE: Must use www.17lands.com/api/card_data with the `event_type` param
+    # and a `time_period` preset (see config.TIME_PERIOD_*). The retired
+    # /card_ratings/data route still answers 200 but ignores the colors and
+    # time_period filters (every archetype collapses into a stale copy of All
+    # Decks), and api.17lands.com remains a different, unsuitable host.
+    base_url = "https://www.17lands.com/api/card_data"
 
     for i, color in enumerate(valid_archetypes):
         logger.info(
@@ -199,7 +198,7 @@ def extract_17lands_data(
 
         params = {
             "expansion": set_code,
-            "format": draft_format,
+            "event_type": draft_format,
             "time_period": time_period,
         }
         if color != "All Decks":
@@ -208,7 +207,9 @@ def extract_17lands_data(
             params["user_group"] = user_group.lower()
 
         try:
-            data = client.respectful_get(base_url, params=params).json()
+            payload = client.respectful_get(base_url, params=params).json()
+            # /api/card_data wraps the card list in {copyright, notes, data}
+            data = payload.get("data") or [] if isinstance(payload, dict) else payload
             if color == "All Decks" and not data:
                 break
 

--- a/server/extract.py
+++ b/server/extract.py
@@ -181,15 +181,15 @@ def extract_17lands_data(
     draft_format: str,
     valid_archetypes: list,
     user_group: str,
-    start_date: str,
-    end_date: str,
+    time_period: str,
 ) -> dict:
     archetype_data = {}
     # NOTE: Must use www.17lands.com (not api.17lands.com). The api host serves a
-    # limited default snapshot that ignores start_date/end_date and the colors
-    # filter, which silently collapses every archetype into a tiny "All Decks"
-    # sample. www.17lands.com honors the full query (matches color_ratings and
-    # the client in src/seventeenlands.py).
+    # limited default snapshot that collapses every archetype into a tiny sample.
+    #
+    # 17Lands replaced start_date/end_date ranges with a `time_period` preset
+    # (the site's drop-down). Without it the endpoint defaults to LAST_DAY, which
+    # is why we were seeing a single day of data. See config.TIME_PERIOD_*.
     base_url = "https://www.17lands.com/card_ratings/data"
 
     for i, color in enumerate(valid_archetypes):
@@ -200,8 +200,7 @@ def extract_17lands_data(
         params = {
             "expansion": set_code,
             "format": draft_format,
-            "start_date": start_date,
-            "end_date": end_date,
+            "time_period": time_period,
         }
         if color != "All Decks":
             params["colors"] = color
@@ -269,8 +268,7 @@ def extract_color_ratings(
     set_code: str,
     draft_format: str,
     user_group: str,
-    start_date: str,
-    end_date: str,
+    time_period: str,
 ) -> tuple[dict, dict, int]:
     logger.info(
         f"Fetching color ratings for {set_code} {draft_format} ({user_group})..."
@@ -279,8 +277,7 @@ def extract_color_ratings(
     params = {
         "expansion": set_code,
         "event_type": draft_format,
-        "start_date": start_date,
-        "end_date": end_date,
+        "time_period": time_period,
         "combine_splash": "true",
     }
     if user_group != "All":

--- a/server/main.py
+++ b/server/main.py
@@ -101,6 +101,9 @@ def run_pipeline():
 
     jobs = []
     for set_code, data in active_sets.items():
+        # The date range no longer drives the 17Lands request (it uses a
+        # time_period preset now), but we still record the true start date in
+        # each dataset's meta so the UI can show the window being represented.
         if "CUBE" in set_code.upper():
             true_start_date_str = data["start_date"]
         else:
@@ -119,9 +122,10 @@ def run_pipeline():
 
     for set_code, draft_format, user_group, start_date_str in jobs:
         logger.info(f"==== Processing {set_code} | {draft_format} | {user_group} ====")
-        window = "ALL-TIME" if "CUBE" not in set_code.upper() else "event window"
+        time_period = config.default_time_period(set_code)
         logger.info(
-            f"   Effective window ({window}): {start_date_str} -> {end_date_str}"
+            f"   Requesting 17Lands time_period={time_period} "
+            f"(represents {start_date_str} -> {end_date_str})"
         )
 
         try:
@@ -158,7 +162,7 @@ def run_pipeline():
                 )
 
             color_ratings, games_played, total_games = extract_color_ratings(
-                client, set_code, draft_format, user_group, start_date_str, end_date_str
+                client, set_code, draft_format, user_group, time_period
             )
 
             valid_archetypes = ["All Decks"]
@@ -185,8 +189,7 @@ def run_pipeline():
                 draft_format,
                 valid_archetypes,
                 user_group,
-                start_date_str,
-                end_date_str,
+                time_period,
             )
 
             if not seventeenlands_data.get("All Decks"):

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -101,6 +101,10 @@ class Settings(BaseModel):
     arena_log_location: str = ""
     database_location: str = ""
 
+    # Tracks the app version of the last successful launch so we can run one-time
+    # migrations on upgrade (e.g. forcing a corrected-dataset refresh).
+    last_run_version: str = ""
+
     @field_validator("deck_filter")
     @classmethod
     def validate_deck_filter(cls, value, info):

--- a/src/constants.py
+++ b/src/constants.py
@@ -31,9 +31,9 @@ def get_resource_dir():
 BASE_DIR = get_base_dir()
 RESOURCE_DIR = get_resource_dir()
 
-APPLICATION_VERSION = "4.17"
+APPLICATION_VERSION = "4.18"
 OLD_APPLICATION_VERSION = "4.17"
-PREVIOUS_APPLICATION_VERSION = "0416"
+PREVIOUS_APPLICATION_VERSION = "0417"
 
 FONT_SANS_SERIF = "Arial"
 FONT_MONO_SPACE = "Courier"
@@ -465,6 +465,37 @@ LIMITED_GROUPS_LIST = [
     LIMITED_USER_GROUP_MIDDLE,
     LIMITED_USER_GROUP_BOTTOM,
 ]
+
+# 17Lands replaced custom start_date/end_date ranges with these preset
+# "time_period" values (the drop-down on the card pages). Maps the UI label to
+# the query value the endpoint expects; confirm against the browser Network tab
+# if a preset ever stops returning data.
+TIME_PERIOD_OPTIONS = {
+    "All Time": "ALL_TIME",
+    "Latest Event": "LATEST_EVENT",
+    "Last Two Weeks": "LAST_TWO_WEEKS",
+    "Last Week": "LAST_WEEK",
+    "Last Day": "LAST_DAY",
+    "First Week": "FIRST_WEEK",
+    "All Except First Week": "ALL_EXCEPT_FIRST_WEEK",
+}
+TIME_PERIOD_LABELS = list(TIME_PERIOD_OPTIONS.keys())
+TIME_PERIOD_DEFAULT_LABEL = "All Time"
+TIME_PERIOD_DEFAULT = "ALL_TIME"
+
+
+def time_period_value(label: str) -> str:
+    """UI label -> 17Lands query value, falling back to All Time."""
+    return TIME_PERIOD_OPTIONS.get(label, TIME_PERIOD_DEFAULT)
+
+
+def time_period_label(value: str) -> str:
+    """17Lands query value -> UI label, falling back to All Time."""
+    for lbl, val in TIME_PERIOD_OPTIONS.items():
+        if val == value:
+            return lbl
+    return TIME_PERIOD_DEFAULT_LABEL
+
 
 SET_TYPE_EXPANSION = "expansion"
 SET_TYPE_ALCHEMY = "alchemy"

--- a/src/file_extractor.py
+++ b/src/file_extractor.py
@@ -232,6 +232,7 @@ class FileExtractor(UIProgress):
         self.session = ""
         self.start_date = ""
         self.end_date = ""
+        self.time_period = constants.TIME_PERIOD_DEFAULT
         self.user_group = ""
         self.directory = directory
         self.card_ratings = {}
@@ -272,6 +273,14 @@ class FileExtractor(UIProgress):
             self.end_date = end_date
             self.combined_data["meta"]["end_date"] = self.end_date
         return result
+
+    def set_time_period(self, time_period):
+        """Sets the 17Lands time_period preset (ALL_TIME, LATEST_EVENT, ...) used
+        for fetching. Replaces the old custom start_date/end_date range, which
+        17Lands no longer honors. The start/end dates are still recorded in meta
+        for display purposes."""
+        self.time_period = time_period or constants.TIME_PERIOD_DEFAULT
+        self.combined_data["meta"]["time_period"] = self.time_period
 
     def set_user_group(self, user_group):
         """Sets the user_group filter in a set file (all/bottom/middle/top)"""
@@ -362,8 +371,7 @@ class FileExtractor(UIProgress):
             deep_ratings = sl.download_set_data(
                 set_code,
                 self.draft,
-                self.start_date,
-                self.end_date,
+                self.time_period,
                 colors=target_colors,
                 user_group=self.user_group,
                 progress_callback=update_ui,
@@ -1150,8 +1158,7 @@ class FileExtractor(UIProgress):
                             set_code,
                             color,
                             self.draft,
-                            self.start_date,
-                            self.end_date,
+                            self.time_period,
                             self.user_group,
                             self.card_ratings,
                         )
@@ -1218,8 +1225,7 @@ class FileExtractor(UIProgress):
                     seventeenlands.download_color_ratings(
                         self.selected_sets.seventeenlands[0],
                         self.draft,
-                        self.start_date,
-                        self.end_date,
+                        self.time_period,
                         self.user_group,
                         threshold=self.threshold,
                     )

--- a/src/seventeenlands.py
+++ b/src/seventeenlands.py
@@ -33,8 +33,7 @@ class Seventeenlands:
         self,
         set_code: str,
         draft_format: str,
-        start_date: str,
-        end_date: str,
+        time_period: str,
         colors: List[str] = None,
         user_group: str = "All",
         progress_callback=None,
@@ -69,7 +68,7 @@ class Seventeenlands:
 
             # Fetch raw data (from cache or network)
             raw_data, from_cache = self._fetch_archetype_with_cache(
-                set_code, draft_format, start_date, end_date, color, user_group
+                set_code, draft_format, time_period, color, user_group
             )
 
             # Process into master map
@@ -88,15 +87,16 @@ class Seventeenlands:
         self,
         set_code: str,
         draft_format: str,
-        start_date: str,
-        end_date: str,
+        time_period: str,
         color: str,
         user_group: str = "All",
     ):
         """Retrieves data from 17Lands, prioritizing the local raw cache."""
         ug_label = user_group if user_group and user_group != "All" else "All"
 
-        cache_name = f"{set_code}_{draft_format}_{start_date}_{end_date}_{color}_{ug_label}.json".lower()
+        cache_name = (
+            f"{set_code}_{draft_format}_{time_period}_{color}_{ug_label}.json".lower()
+        )
 
         cache_path = os.path.join(self.CACHE_DIR, cache_name)
 
@@ -111,10 +111,11 @@ class Seventeenlands:
             except json.JSONDecodeError:
                 pass  # Cache corrupt, fetch new
 
-        # Build URL
+        # Build URL. 17Lands uses a time_period preset (ALL_TIME, LAST_DAY, ...)
+        # instead of start_date/end_date ranges, which it now ignores.
         url = (
             f"{self.URL_BASE}/card_ratings/data?expansion={set_code.upper()}"
-            f"&format={draft_format}&start_date={start_date}&end_date={end_date}"
+            f"&format={draft_format}&time_period={time_period}"
         )
         if color != "All" and color != "All Decks":
             url += f"&colors={color}"
@@ -209,8 +210,7 @@ class Seventeenlands:
         self,
         set_code,
         draft,
-        start_date,
-        end_date,
+        time_period,
         user_group,
         threshold=5000,
         color_filter=None,
@@ -219,8 +219,7 @@ class Seventeenlands:
         params = {
             "expansion": set_code,
             "event_type": draft,
-            "start_date": start_date,
-            "end_date": end_date,
+            "time_period": time_period,
             "combine_splash": True,
         }
         if user_group and user_group.lower() != "all":
@@ -275,7 +274,7 @@ class Seventeenlands:
 
     # RESTORED LEGACY METHOD
     def download_card_ratings(
-        self, set_code, color, draft, start_date, end_date, user_group, card_data
+        self, set_code, color, draft, time_period, user_group, card_data
     ):
         """
         Legacy method to populate a card dictionary with 17Lands data.
@@ -284,8 +283,7 @@ class Seventeenlands:
         params = {
             "expansion": set_code,
             "format": draft,
-            "start_date": start_date,
-            "end_date": end_date,
+            "time_period": time_period,
             "colors": color if color != "All Decks" else None,
         }
 
@@ -340,10 +338,8 @@ class Seventeenlands:
             }
             card_data[name][constants.DATA_SECTION_RATINGS].append({color: entry})
 
-    def build_card_ratings_url(
-        self, set_code, draft, start_date, end_date, user_group, color
-    ):
-        base = f"{self.URL_BASE}/card_ratings/data?expansion={set_code}&format={draft}&start_date={start_date}&end_date={end_date}"
+    def build_card_ratings_url(self, set_code, draft, time_period, user_group, color):
+        base = f"{self.URL_BASE}/card_ratings/data?expansion={set_code}&format={draft}&time_period={time_period}"
         if user_group and user_group != "All":
             base += f"&user_group={user_group}"
         if color and color != "All Decks":

--- a/src/seventeenlands.py
+++ b/src/seventeenlands.py
@@ -29,6 +29,14 @@ class Seventeenlands:
         if not os.path.exists(self.CACHE_DIR):
             os.makedirs(self.CACHE_DIR)
 
+    @staticmethod
+    def _unwrap_card_payload(payload) -> List[Dict]:
+        """/api/card_data wraps the card list in {copyright, notes, data};
+        older responses/caches are a bare list. Accept both."""
+        if isinstance(payload, dict):
+            return payload.get("data") or []
+        return payload or []
+
     def download_set_data(
         self,
         set_code: str,
@@ -94,8 +102,10 @@ class Seventeenlands:
         """Retrieves data from 17Lands, prioritizing the local raw cache."""
         ug_label = user_group if user_group and user_group != "All" else "All"
 
+        # The _v2 marker skips cache files fetched from the retired
+        # /card_ratings/data route, which served degraded data.
         cache_name = (
-            f"{set_code}_{draft_format}_{time_period}_{color}_{ug_label}.json".lower()
+            f"{set_code}_{draft_format}_{time_period}_{color}_{ug_label}_v2.json".lower()
         )
 
         cache_path = os.path.join(self.CACHE_DIR, cache_name)
@@ -111,11 +121,13 @@ class Seventeenlands:
             except json.JSONDecodeError:
                 pass  # Cache corrupt, fetch new
 
-        # Build URL. 17Lands uses a time_period preset (ALL_TIME, LAST_DAY, ...)
-        # instead of start_date/end_date ranges, which it now ignores.
+        # Build URL. Card ratings live at /api/card_data with an `event_type`
+        # param and a time_period preset (ALL_TIME, LATEST_EVENT, ...). The old
+        # /card_ratings/data route still answers 200 but ignores the colors and
+        # time_period filters, so it must not be used.
         url = (
-            f"{self.URL_BASE}/card_ratings/data?expansion={set_code.upper()}"
-            f"&format={draft_format}&time_period={time_period}"
+            f"{self.URL_BASE}/api/card_data?expansion={set_code.upper()}"
+            f"&event_type={draft_format}&time_period={time_period}"
         )
         if color != "All" and color != "All Decks":
             url += f"&colors={color}"
@@ -124,7 +136,7 @@ class Seventeenlands:
 
         response = self.session.get(url, timeout=30)
         response.raise_for_status()
-        data = response.json()
+        data = self._unwrap_card_payload(response.json())
 
         # Only save to cache if we actually received data
         if data and len(data) > 0:
@@ -282,7 +294,7 @@ class Seventeenlands:
         """
         params = {
             "expansion": set_code,
-            "format": draft,
+            "event_type": draft,
             "time_period": time_period,
             "colors": color if color != "All Decks" else None,
         }
@@ -290,10 +302,10 @@ class Seventeenlands:
         if user_group and user_group.lower() != "all":
             params["user_group"] = user_group
 
-        url = f"{self.URL_BASE}/card_ratings/data"
+        url = f"{self.URL_BASE}/api/card_data"
         response = self.session.get(url, params=params, timeout=30)
         response.raise_for_status()
-        data = response.json()
+        data = self._unwrap_card_payload(response.json())
         self.process_card_ratings(color, data, card_data)
 
     def process_card_ratings(self, color, data, card_data):
@@ -339,7 +351,7 @@ class Seventeenlands:
             card_data[name][constants.DATA_SECTION_RATINGS].append({color: entry})
 
     def build_card_ratings_url(self, set_code, draft, time_period, user_group, color):
-        base = f"{self.URL_BASE}/card_ratings/data?expansion={set_code}&format={draft}&time_period={time_period}"
+        base = f"{self.URL_BASE}/api/card_data?expansion={set_code}&event_type={draft}&time_period={time_period}"
         if user_group and user_group != "All":
             base += f"&user_group={user_group}"
         if color and color != "All Decks":

--- a/src/ui/windows/download.py
+++ b/src/ui/windows/download.py
@@ -24,6 +24,7 @@ class DatasetArgs:
     user_group: str
     game_count: int
     color_ratings: Optional[dict] = None
+    time_period: str = constants.TIME_PERIOD_DEFAULT
 
 
 class DownloadWindow(ttk.Frame):
@@ -209,27 +210,40 @@ class DownloadWindow(ttk.Frame):
             row=1, column=3, sticky="ew", pady=Theme.scaled_val(2)
         )
 
+        # 17Lands replaced custom start/end date ranges with time_period presets.
+        # We still track start/end internally (set-start -> today) for the dataset
+        # meta and the table, but the user now picks a preset instead.
         self.vars["start"] = tkinter.StringVar(value="2019-01-01")
-        ttk.Label(form, text="START DATE:").grid(
+        self.vars["end"] = tkinter.StringVar(value=str(date.today()))
+
+        self.vars["period"] = tkinter.StringVar(
+            value=constants.TIME_PERIOD_DEFAULT_LABEL
+        )
+        ttk.Label(form, text="TIME PERIOD:").grid(
             row=2, column=0, sticky="e", padx=Theme.scaled_val(5)
         )
-        ttk.Entry(form, textvariable=self.vars["start"]).grid(
-            row=2, column=1, sticky="ew", pady=Theme.scaled_val(2)
-        )
-
-        self.vars["end"] = tkinter.StringVar(value=str(date.today()))
-        ttk.Label(form, text="END DATE:").grid(
-            row=2, column=2, sticky="e", padx=Theme.scaled_val(5)
-        )
-        ttk.Entry(form, textvariable=self.vars["end"]).grid(
-            row=2, column=3, sticky="ew", pady=Theme.scaled_val(2)
-        )
+        ttk.OptionMenu(
+            form,
+            self.vars["period"],
+            constants.TIME_PERIOD_DEFAULT_LABEL,
+            *constants.TIME_PERIOD_LABELS,
+        ).grid(row=2, column=1, sticky="ew", pady=Theme.scaled_val(2))
 
         self.btn_dl = ttk.Button(
             form, text="Download Selected Dataset", command=self._manual_download
         )
         self.btn_dl.grid(
             row=3, column=0, columnspan=4, pady=Theme.scaled_val((10, 0)), sticky="ew"
+        )
+
+        self.btn_clear = ttk.Button(
+            form,
+            text="Clear Set History",
+            command=self._clear_set_history,
+            bootstyle="secondary",
+        )
+        self.btn_clear.grid(
+            row=4, column=0, columnspan=4, pady=Theme.scaled_val((5, 0)), sticky="ew"
         )
 
         self.progress = ttk.Progressbar(container, mode="determinate")
@@ -324,11 +338,40 @@ class DownloadWindow(ttk.Frame):
             self.vars["group"].set(args.user_group)
             self.vars["start"].set(args.start)
             self.vars["end"].set(args.end)
+            self.vars["period"].set(constants.time_period_label(args.time_period))
             self.update_idletasks()
             self._start_download(args)
 
     def _manual_download(self):
         self._start_download()
+
+    def _clear_set_history(self):
+        """Deletes all locally downloaded datasets and schedules a fresh refresh on
+        the next launch's splash screen. Useful when accumulated old sets slow
+        loading or after a data-format change."""
+        if not messagebox.askyesno(
+            "Clear Set History",
+            "Delete all downloaded datasets?\n\nThe latest 17Lands data will be "
+            "re-downloaded automatically the next time you start the app.",
+        ):
+            return
+
+        from src.utils import clear_set_history
+
+        removed = clear_set_history()
+
+        # The active dataset file may now be gone, and resetting the version marker
+        # makes the next launch perform the one-time corrected-data refresh.
+        self.configuration.card_data.latest_dataset = ""
+        self.configuration.settings.last_run_version = ""
+        write_configuration(self.configuration)
+
+        self._update_table()
+        messagebox.showinfo(
+            "Set History Cleared",
+            f"Removed {removed} dataset(s). Restart the app to download fresh "
+            "17Lands data.",
+        )
 
     def _on_set_change(self, val):
         s_info = self.sets_data.get(val)
@@ -401,6 +444,7 @@ class DownloadWindow(ttk.Frame):
             "event": self.vars["event"].get(),
             "start": self.vars["start"].get(),
             "end": self.vars["end"].get(),
+            "time_period": constants.time_period_value(self.vars["period"].get()),
             "group": self.vars["group"].get(),
             "db_loc": self.configuration.settings.database_location,
             "threshold": threshold,
@@ -429,6 +473,7 @@ class DownloadWindow(ttk.Frame):
             ex.set_draft_type(ctx["event"])
             ex.set_start_date(ctx["start"])
             ex.set_end_date(ctx["end"])
+            ex.set_time_period(ctx["time_period"])
             ex.set_user_group(ctx["group"])
             ex.set_version(3.0)
             suc = True

--- a/src/utils.py
+++ b/src/utils.py
@@ -91,6 +91,27 @@ def invalidate_local_set_cache():
     _LOCAL_SET_CACHE["mtime"] = 0.0
 
 
+def clear_set_history() -> int:
+    """Deletes all downloaded 17Lands datasets and the local manifest so the app
+    re-syncs a clean copy. Frees disk and speeds up loading when many old sets
+    have accumulated. Returns the number of dataset files removed."""
+    if not os.path.isdir(SETS_FOLDER):
+        return 0
+
+    removed = 0
+    for name in os.listdir(SETS_FOLDER):
+        if name.endswith(SET_FILE_SUFFIX) or name == "local_manifest.json":
+            try:
+                os.remove(os.path.join(SETS_FOLDER, name))
+                if name.endswith(SET_FILE_SUFFIX):
+                    removed += 1
+            except OSError:
+                pass
+
+    invalidate_local_set_cache()
+    return removed
+
+
 def retrieve_local_set_list(codes=None, names=None):
     """Scans the Sets folder and returns a list of valid set files (Highly Cached)"""
     global _LOCAL_SET_CACHE
@@ -383,6 +404,29 @@ def is_cache_stale(filepath: str, hours: int = 24) -> bool:
         return True
     file_age_seconds = time.time() - os.path.getmtime(filepath)
     return file_age_seconds > (hours * 3600)
+
+
+def purge_raw_cache() -> int:
+    """Deletes the raw 17Lands response cache (Temp/RawCache) and returns the
+    number of files removed. Used on upgrade to drop entries keyed by the old
+    start_date/end_date scheme, which are orphaned once fetching switches to the
+    time_period presets."""
+    from src.constants import BASE_DIR
+
+    cache_dir = os.path.join(BASE_DIR, "Temp", "RawCache")
+    if not os.path.isdir(cache_dir):
+        return 0
+
+    removed = 0
+    for name in os.listdir(cache_dir):
+        path = os.path.join(cache_dir, name)
+        try:
+            if os.path.isfile(path):
+                os.remove(path)
+                removed += 1
+        except OSError:
+            pass
+    return removed
 
 
 def sanitize_card_name(name: str) -> str:

--- a/tests/server/test_extract.py
+++ b/tests/server/test_extract.py
@@ -17,20 +17,25 @@ def test_extract_17lands_data(mock_client):
     """Verifies that raw 17Lands data is parsed into strict percentage floats and captures image URLs."""
 
     mock_response = MagicMock()
-    mock_response.json.return_value = [
-        {
-            "name": "Lightning Bolt",
-            "mtga_id": 12345,
-            "ever_drawn_win_rate": 0.6254,
-            "opening_hand_win_rate": 0.591,
-            "win_rate": 0.58,
-            "drawn_improvement_win_rate": 0.045,
-            "avg_seen": 2.1,
-            "avg_pick": 2.0,
-            "ever_drawn_game_count": 5000,
-            "url": "/static/images/cards/bolt.jpg",
-        }
-    ]
+    # /api/card_data wraps the card list in a {copyright, notes, data} envelope
+    mock_response.json.return_value = {
+        "copyright": "(c) 2026 17Lands LLC",
+        "notes": "usage notes",
+        "data": [
+            {
+                "name": "Lightning Bolt",
+                "mtga_id": 12345,
+                "ever_drawn_win_rate": 0.6254,
+                "opening_hand_win_rate": 0.591,
+                "win_rate": 0.58,
+                "drawn_improvement_win_rate": 0.045,
+                "avg_seen": 2.1,
+                "avg_pick": 2.0,
+                "ever_drawn_game_count": 5000,
+                "url": "/static/images/cards/bolt.jpg",
+            }
+        ],
+    }
     mock_client.respectful_get.return_value = mock_response
 
     # Act
@@ -60,13 +65,14 @@ def test_extract_17lands_data(mock_client):
     )
 
 
-def test_extract_17lands_data_uses_www_host_and_color_filter(mock_client):
-    """Regression: card ratings must hit www.17lands.com (which honors start_date/
-    end_date and the colors filter), NOT api.17lands.com (a limited snapshot that
-    ignores them, collapsing every archetype into an identical tiny sample)."""
+def test_extract_17lands_data_uses_api_card_data_endpoint(mock_client):
+    """Regression: card ratings must hit www.17lands.com/api/card_data with the
+    event_type param. The old /card_ratings/data route still answers 200 but
+    ignores colors/time_period, collapsing every archetype into an identical
+    stale snapshot (and api.17lands.com remains a different, unsuitable host)."""
 
     mock_response = MagicMock()
-    mock_response.json.return_value = [{"name": "Some Card", "mtga_id": 1}]
+    mock_response.json.return_value = {"data": [{"name": "Some Card", "mtga_id": 1}]}
     mock_client.respectful_get.return_value = mock_response
 
     extract_17lands_data(
@@ -79,11 +85,11 @@ def test_extract_17lands_data_uses_www_host_and_color_filter(mock_client):
     )
 
     calls = mock_client.respectful_get.call_args_list
-    assert calls, "expected at least one card_ratings request"
+    assert calls, "expected at least one card data request"
 
     for call in calls:
         url = call.args[0] if call.args else call.kwargs["url"]
-        assert url == "https://www.17lands.com/card_ratings/data"
+        assert url == "https://www.17lands.com/api/card_data"
 
     # The "All Decks" request must not carry a colors filter; the "WU"
     # request must, so the per-archetype data is actually distinct.
@@ -91,6 +97,10 @@ def test_extract_17lands_data_uses_www_host_and_color_filter(mock_client):
     wu_params = calls[1].kwargs["params"]
     assert "colors" not in all_decks_params
     assert wu_params["colors"] == "WU"
+    # The endpoint renamed format -> event_type; sending the old param would be
+    # silently ignored.
+    assert all_decks_params["event_type"] == "PremierDraft"
+    assert "format" not in all_decks_params
     # ALL_TIME preset must be sent so the endpoint returns full history rather
     # than defaulting to its LAST_DAY drop-down value. Legacy date params are gone.
     assert all_decks_params["time_period"] == "ALL_TIME"

--- a/tests/server/test_extract.py
+++ b/tests/server/test_extract.py
@@ -40,8 +40,7 @@ def test_extract_17lands_data(mock_client):
         draft_format="PremierDraft",
         valid_archetypes=["All Decks", "UR"],
         user_group="All",
-        start_date="2020-01-01",
-        end_date="2024-01-01",
+        time_period="ALL_TIME",
     )
 
     # Assert
@@ -76,8 +75,7 @@ def test_extract_17lands_data_uses_www_host_and_color_filter(mock_client):
         draft_format="PremierDraft",
         valid_archetypes=["All Decks", "WU"],
         user_group="All",
-        start_date="2026-06-23",
-        end_date="2026-07-08",
+        time_period="ALL_TIME",
     )
 
     calls = mock_client.respectful_get.call_args_list
@@ -93,8 +91,12 @@ def test_extract_17lands_data_uses_www_host_and_color_filter(mock_client):
     wu_params = calls[1].kwargs["params"]
     assert "colors" not in all_decks_params
     assert wu_params["colors"] == "WU"
-    assert wu_params["start_date"] == "2026-06-23"
-    assert wu_params["end_date"] == "2026-07-08"
+    # ALL_TIME preset must be sent so the endpoint returns full history rather
+    # than defaulting to its LAST_DAY drop-down value. Legacy date params are gone.
+    assert all_decks_params["time_period"] == "ALL_TIME"
+    assert wu_params["time_period"] == "ALL_TIME"
+    assert "start_date" not in wu_params
+    assert "end_date" not in wu_params
 
 
 def test_extract_color_ratings(mock_client):
@@ -112,7 +114,7 @@ def test_extract_color_ratings(mock_client):
     mock_client.respectful_get.return_value = mock_response
 
     ratings, games_played, total_games = extract_color_ratings(
-        mock_client, "M10", "PremierDraft", "All", "2020-01-01", "2024-01-01"
+        mock_client, "M10", "PremierDraft", "All", "ALL_TIME"
     )
 
     # Assertions

--- a/tests/test_download_panel.py
+++ b/tests/test_download_panel.py
@@ -177,6 +177,43 @@ class TestDownloadPanel:
             mock_remove.assert_called_once_with(target_file)
             mock_update.assert_called_once()
 
+    @patch("src.ui.windows.download.write_configuration")
+    @patch("src.utils.clear_set_history", return_value=3)
+    @patch("tkinter.messagebox.showinfo")
+    @patch("tkinter.messagebox.askyesno", return_value=True)
+    def test_clear_set_history_button(
+        self,
+        mock_ask,
+        mock_info,
+        mock_clear,
+        mock_write,
+        root,
+        mock_sets_data,
+        config,
+    ):
+        """Clear Set History wipes datasets and resets the version marker so the
+        next launch performs a fresh refresh."""
+        panel = DownloadWindow(root, mock_sets_data, config, MagicMock())
+
+        with patch.object(panel, "_update_table"):
+            panel._clear_set_history()
+
+        mock_clear.assert_called_once()
+        assert config.settings.last_run_version == ""
+        assert config.card_data.latest_dataset == ""
+        mock_write.assert_called_once()
+        mock_info.assert_called_once()
+
+    @patch("tkinter.messagebox.askyesno", return_value=False)
+    def test_clear_set_history_button_cancelled(
+        self, mock_ask, root, mock_sets_data, config
+    ):
+        """Declining the confirmation must not delete anything."""
+        panel = DownloadWindow(root, mock_sets_data, config, MagicMock())
+        with patch("src.utils.clear_set_history") as mock_clear:
+            panel._clear_set_history()
+            mock_clear.assert_not_called()
+
     @patch("tkinter.messagebox.showwarning")
     def test_delete_dataset_blocked_if_active(
         self, mock_warn, root, mock_sets_data, config

--- a/tests/test_seventeenlands.py
+++ b/tests/test_seventeenlands.py
@@ -105,8 +105,8 @@ def test_build_card_ratings_url(seventeenlands):
 
     # Assert
     expected_url = (
-        "https://www.17lands.com/card_ratings/data?expansion=TLA"
-        "&format=PremierDraft&time_period=ALL_TIME"
+        "https://www.17lands.com/api/card_data?expansion=TLA"
+        "&event_type=PremierDraft&time_period=ALL_TIME"
     )
     assert url == expected_url
 
@@ -116,16 +116,21 @@ def test_download_card_ratings(mock_session, seventeenlands):
     Tests the download_card_ratings function to ensure it fetches and processes data correctly.
     """
     session, response = mock_session
-    response.json.return_value = [
-        {
-            "name": "Test Card",
-            "url": "/static/images/cards/test_card.jpg",
-            "ever_drawn_win_rate": 0.6,
-            "avg_seen": 2.5,
-            "drawn_improvement_win_rate": 0.05,
-            "drawn_game_count": 1000,
-        }
-    ]
+    # /api/card_data wraps the card list in a {copyright, notes, data} envelope
+    response.json.return_value = {
+        "copyright": "(c) 2026 17Lands LLC",
+        "notes": "usage notes",
+        "data": [
+            {
+                "name": "Test Card",
+                "url": "/static/images/cards/test_card.jpg",
+                "ever_drawn_win_rate": 0.6,
+                "avg_seen": 2.5,
+                "drawn_improvement_win_rate": 0.05,
+                "drawn_game_count": 1000,
+            }
+        ],
+    }
 
     set_code = "TLA"
     draft = "PremierDraft"
@@ -146,6 +151,14 @@ def test_download_card_ratings(mock_session, seventeenlands):
     ]
     assert len(card_data["Test Card"][constants.DATA_SECTION_RATINGS]) == 1
     session.get.assert_called_once()
+
+    # The old /card_ratings/data route silently ignores filters; make sure we
+    # hit /api/card_data with its renamed event_type param.
+    called_url = session.get.call_args[0][0]
+    called_params = session.get.call_args[1]["params"]
+    assert called_url == "https://www.17lands.com/api/card_data"
+    assert called_params["event_type"] == "PremierDraft"
+    assert "format" not in called_params
 
 
 def test_download_color_ratings(mock_session, seventeenlands):
@@ -278,7 +291,7 @@ def test_fetch_archetype_with_cache_hit(mock_stale, seventeenlands, tmp_path):
 
     # Override CACHE_DIR to our tmp_path
     seventeenlands.CACHE_DIR = str(tmp_path)
-    cache_path = tmp_path / "otj_premierdraft_all_time_all_all.json"
+    cache_path = tmp_path / "otj_premierdraft_all_time_all_all_v2.json"
     cache_path.write_text(json.dumps([{"name": "Cached Card"}]))
 
     # Act
@@ -299,7 +312,7 @@ def test_fetch_archetype_with_cache_miss_writes_to_disk(
     """Verify that a cache miss hits the network and safely writes a new cache file."""
     mock_stale.return_value = True
     session, response = mock_session
-    response.json.return_value = [{"name": "Network Card"}]
+    response.json.return_value = {"data": [{"name": "Network Card"}]}
 
     seventeenlands.CACHE_DIR = str(tmp_path)
 
@@ -313,9 +326,38 @@ def test_fetch_archetype_with_cache_miss_writes_to_disk(
     assert data[0]["name"] == "Network Card"
     assert session.get.call_count == 1
 
-    # Verify the cache file was actually created by the method
-    cache_path = tmp_path / "otj_premierdraft_all_time_all_all.json"
+    # Must hit the new /api/card_data endpoint with event_type (the old
+    # /card_ratings/data route ignores colors/time_period).
+    called_url = session.get.call_args[0][0]
+    assert "/api/card_data?" in called_url
+    assert "event_type=PremierDraft" in called_url
+    assert "format=" not in called_url
+
+    # Verify the cache file was actually created by the method, storing the
+    # unwrapped card list (v2 marker skips stale pre-migration cache files)
+    cache_path = tmp_path / "otj_premierdraft_all_time_all_all_v2.json"
     assert cache_path.exists()
+    assert json.loads(cache_path.read_text())[0]["name"] == "Network Card"
+
+
+@patch("src.seventeenlands.is_cache_stale")
+def test_fetch_archetype_tolerates_bare_list_payload(
+    mock_stale, mock_session, seventeenlands, tmp_path
+):
+    """A bare JSON array (old response shape) must still parse, so any future
+    un-wrapping by 17Lands doesn't break the client."""
+    mock_stale.return_value = True
+    session, response = mock_session
+    response.json.return_value = [{"name": "Bare Card"}]
+
+    seventeenlands.CACHE_DIR = str(tmp_path)
+
+    data, from_cache = seventeenlands._fetch_archetype_with_cache(
+        "OTJ", "PremierDraft", "ALL_TIME", "All", "All"
+    )
+
+    assert from_cache is False
+    assert data[0]["name"] == "Bare Card"
 
 
 def test_download_color_ratings_http_errors(mock_session, seventeenlands):

--- a/tests/test_seventeenlands.py
+++ b/tests/test_seventeenlands.py
@@ -94,20 +94,19 @@ def test_build_card_ratings_url(seventeenlands):
     # Arrange
     set_code = "TLA"
     draft = "PremierDraft"
-    start_date = "2023-01-01"
-    end_date = "2025-11-28"
+    time_period = "ALL_TIME"
     user_group = constants.LIMITED_USER_GROUP_ALL
     color = constants.FILTER_OPTION_ALL_DECKS
 
     # Act
     url = seventeenlands.build_card_ratings_url(
-        set_code, draft, start_date, end_date, user_group, color
+        set_code, draft, time_period, user_group, color
     )
 
     # Assert
     expected_url = (
         "https://www.17lands.com/card_ratings/data?expansion=TLA"
-        "&format=PremierDraft&start_date=2023-01-01&end_date=2025-11-28"
+        "&format=PremierDraft&time_period=ALL_TIME"
     )
     assert url == expected_url
 
@@ -130,15 +129,14 @@ def test_download_card_ratings(mock_session, seventeenlands):
 
     set_code = "TLA"
     draft = "PremierDraft"
-    start_date = "2023-01-01"
-    end_date = "2025-11-28"
+    time_period = "ALL_TIME"
     user_group = constants.LIMITED_USER_GROUP_ALL
     color = constants.FILTER_OPTION_ALL_DECKS
     card_data = {}
 
     # Act
     seventeenlands.download_card_ratings(
-        set_code, color, draft, start_date, end_date, user_group, card_data
+        set_code, color, draft, time_period, user_group, card_data
     )
 
     # Assert
@@ -171,13 +169,12 @@ def test_download_color_ratings(mock_session, seventeenlands):
 
     set_code = "TLA"
     draft = "PremierDraft"
-    start_date = "2023-01-01"
-    end_date = "2025-11-28"
+    time_period = "ALL_TIME"
     user_group = constants.LIMITED_USER_GROUP_ALL
 
     # Act
     color_ratings, game_count = seventeenlands.download_color_ratings(
-        set_code, draft, start_date, end_date, user_group
+        set_code, draft, time_period, user_group
     )
 
     # Assert
@@ -201,7 +198,7 @@ def test_seventeenlands_color_ratings_normalization(mock_session, seventeenlands
     # We pass a filter that includes the *Normalized* key "WG"
     # The function should be able to map "GW" from API to "WG"
     ratings, game_count = seventeenlands.download_color_ratings(
-        "SET", "Draft", "Start", "End", "User", color_filter=["WG"]
+        "SET", "Draft", "ALL_TIME", "User", color_filter=["WG"]
     )
 
     # Check that the key in the returned dictionary is normalized to "WG"
@@ -281,12 +278,12 @@ def test_fetch_archetype_with_cache_hit(mock_stale, seventeenlands, tmp_path):
 
     # Override CACHE_DIR to our tmp_path
     seventeenlands.CACHE_DIR = str(tmp_path)
-    cache_path = tmp_path / "otj_premierdraft_2024-01-01_2024-02-01_all_all.json"
+    cache_path = tmp_path / "otj_premierdraft_all_time_all_all.json"
     cache_path.write_text(json.dumps([{"name": "Cached Card"}]))
 
     # Act
     data, from_cache = seventeenlands._fetch_archetype_with_cache(
-        "OTJ", "PremierDraft", "2024-01-01", "2024-02-01", "All", "All"
+        "OTJ", "PremierDraft", "ALL_TIME", "All", "All"
     )
 
     # Assert
@@ -308,7 +305,7 @@ def test_fetch_archetype_with_cache_miss_writes_to_disk(
 
     # Act
     data, from_cache = seventeenlands._fetch_archetype_with_cache(
-        "OTJ", "PremierDraft", "2024-01-01", "2024-02-01", "All", "All"
+        "OTJ", "PremierDraft", "ALL_TIME", "All", "All"
     )
 
     # Assert
@@ -317,7 +314,7 @@ def test_fetch_archetype_with_cache_miss_writes_to_disk(
     assert session.get.call_count == 1
 
     # Verify the cache file was actually created by the method
-    cache_path = tmp_path / "otj_premierdraft_2024-01-01_2024-02-01_all_all.json"
+    cache_path = tmp_path / "otj_premierdraft_all_time_all_all.json"
     assert cache_path.exists()
 
 
@@ -328,9 +325,9 @@ def test_download_color_ratings_http_errors(mock_session, seventeenlands):
     # 429 Too Many Requests
     response.status_code = 429
     with pytest.raises(Exception, match="Rate Limited"):
-        seventeenlands.download_color_ratings("TLA", "Draft", "Start", "End", "All")
+        seventeenlands.download_color_ratings("TLA", "Draft", "ALL_TIME", "All")
 
     # 403 Forbidden (WAF Block)
     response.status_code = 403
     with pytest.raises(Exception, match="Access Denied"):
-        seventeenlands.download_color_ratings("TLA", "Draft", "Start", "End", "All")
+        seventeenlands.download_color_ratings("TLA", "Draft", "ALL_TIME", "All")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -110,3 +110,48 @@ def test_normalize_color_string(input_color, expected_output):
     Verify that color strings are normalized to WUBRG order.
     """
     assert normalize_color_string(input_color) == expected_output
+
+
+def test_purge_raw_cache_removes_files(tmp_path, monkeypatch):
+    """The upgrade migration should clear stale raw-cache entries."""
+    import src.constants as constants_module
+    from src.utils import purge_raw_cache
+
+    monkeypatch.setattr(constants_module, "BASE_DIR", str(tmp_path))
+    cache_dir = tmp_path / "Temp" / "RawCache"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "otj_premierdraft_2024-01-01_2024-02-01_all_all.json").write_text("[]")
+    (cache_dir / "otj_premierdraft_2024-01-02_2024-02-02_wu_all.json").write_text("[]")
+
+    removed = purge_raw_cache()
+
+    assert removed == 2
+    assert list(cache_dir.iterdir()) == []
+
+
+def test_purge_raw_cache_missing_dir_is_safe(tmp_path, monkeypatch):
+    """A missing cache directory must not raise, just report nothing removed."""
+    import src.constants as constants_module
+    from src.utils import purge_raw_cache
+
+    monkeypatch.setattr(constants_module, "BASE_DIR", str(tmp_path))
+    assert purge_raw_cache() == 0
+
+
+def test_clear_set_history_removes_datasets(tmp_path, monkeypatch):
+    """Clearing set history deletes datasets and the manifest but leaves other files."""
+    import src.utils as utils_module
+    from src.utils import clear_set_history
+
+    monkeypatch.setattr(utils_module, "SETS_FOLDER", str(tmp_path))
+    (tmp_path / "MSH_PremierDraft_All_Data.json").write_text("{}")
+    (tmp_path / "BLB_QuickDraft_Top_Data.json").write_text("{}")
+    (tmp_path / "local_manifest.json").write_text("{}")
+    (tmp_path / "unrelated.txt").write_text("keep me")
+
+    removed = clear_set_history()
+
+    assert removed == 2
+    assert not (tmp_path / "MSH_PremierDraft_All_Data.json").exists()
+    assert not (tmp_path / "local_manifest.json").exists()
+    assert (tmp_path / "unrelated.txt").exists()


### PR DESCRIPTION
* unrealities: [Bug] Fixed a major issue where 17Lands card and color statistics only reflected the most recent day of data (e.g. ~500 games instead of the full set). The tool now requests the correct "All Time" period, matching the numbers shown on 17Lands.
* unrealities: [Bug] Migrated card statistics to 17Lands' new `/api/card_data` endpoint. The retired endpoint had stopped honoring the color archetype and time period filters, which made every archetype display identical "All Decks" numbers and left win rates empty in some formats.
* unrealities: [UX/UI] The dataset download screen now offers a Time Period drop-down (All Time, Latest Event, Last Week, etc.) in place of manual start/end dates, mirroring 17Lands.
* unrealities: [UX/UI] On first launch after updating, the app performs a one-time refresh of the corrected 17Lands datasets and clears the stale local cache automatically.

## Verification
- [x] Full test suite: 653 passed, 1 skipped
- [x] Live spot-check through the migrated client: MSH PremierDraft WU archetype differs from All Decks (85,544 vs 184,992 games), win rates populated
- [x] Full ETL run end-to-end: 175 API requests, 0 failed, 12 MSH datasets updated and validated (the only skips are Sealed/TradSealed Top, where 17Lands genuinely withholds win rates for tiny top-player populations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
