### PR TITLE
Label manual downloads with their time_period preset

### DIFF
--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,6 +1,7 @@
 ===================== RELEASE NOTES 4.18 =====================
 * unrealities: [Bug] Fixed a major issue where 17Lands card and color statistics only reflected the most recent day of data (e.g. ~500 games instead of the full set). The tool now requests the correct "All Time" period, matching the numbers shown on 17Lands.
 * unrealities: [Bug] Migrated card statistics to 17Lands' new `/api/card_data` endpoint. The retired endpoint had stopped honoring the color archetype and time period filters, which made every archetype display identical "All Decks" numbers and left win rates empty in some formats.
+* unrealities: [UX/UI] Manual downloads are now labeled with their Time Period preset (e.g. "All (Latest Event)") in the Datasets table instead of a placeholder date range, record the set's true start date, and no longer overwrite each other when different presets are downloaded on the same day.
 * unrealities: [UX/UI] The dataset download screen now offers a Time Period drop-down (All Time, Latest Event, Last Week, etc.) in place of manual start/end dates, mirroring 17Lands.
 * unrealities: [UX/UI] On first launch after updating, the app performs a one-time refresh of the corrected 17Lands datasets and clears the stale local cache automatically.
 

--- a/src/file_extractor.py
+++ b/src/file_extractor.py
@@ -1310,9 +1310,15 @@ class FileExtractor(UIProgress):
         try:
             import time
 
-            s_clean = self.start_date.replace("-", "")
+            # Stamp with the time_period preset (underscore-free so the
+            # filename still splits into 5 segments) plus the fetch date, so
+            # different presets downloaded the same day don't overwrite each
+            # other.
+            period_stamp = "".join(
+                part.capitalize() for part in self.time_period.split("_")
+            )
             e_clean = self.end_date.replace("-", "")
-            custom_stamp = f"Custom-{s_clean}-{e_clean}"
+            custom_stamp = f"Custom-{period_stamp}-{e_clean}"
 
             output_file = "_".join(
                 (

--- a/src/ui/windows/download.py
+++ b/src/ui/windows/download.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from src import constants
 from src.configuration import write_configuration
 from src.file_extractor import FileExtractor
-from src.utils import retrieve_local_set_list
+from src.utils import retrieve_local_set_list, read_local_manifest
 from src.ui.components import DynamicTreeviewManager, AutoScrollbar
 from src.ui.styles import Theme
 
@@ -100,14 +100,7 @@ class DownloadWindow(ttk.Frame):
         set_options = list(self.sets_data.keys())
         active_set_codes = []
 
-        try:
-            manifest_path = os.path.join(constants.SETS_FOLDER, "local_manifest.json")
-            if os.path.exists(manifest_path):
-                with open(manifest_path, "r", encoding="utf-8") as f:
-                    manifest_data = json.load(f)
-                    active_set_codes = manifest_data.get("active_sets", [])
-        except Exception:
-            pass
+        active_set_codes = read_local_manifest().get("active_sets", [])
 
         active_options = []
         inactive_options = []
@@ -345,6 +338,25 @@ class DownloadWindow(ttk.Frame):
     def _manual_download(self):
         self._start_download()
 
+    def _resolve_start_date(self, set_key: str) -> str:
+        """Best-known start date for a set. The set list can be stuck on the
+        placeholder default (stale cache, 17Lands feed gap), so fall back to
+        the earliest start_date the synced dataset manifest records for it."""
+        s_info = self.sets_data.get(set_key)
+        if s_info and s_info.start_date != constants.START_DATE_DEFAULT:
+            return s_info.start_date
+
+        codes = {c.upper() for c in (s_info.seventeenlands if s_info else [])}
+        manifest_dates = [
+            entry["start_date"]
+            for key, entry in read_local_manifest().get("datasets", {}).items()
+            if key.split("_")[0].upper() in codes and entry.get("start_date")
+        ]
+        if manifest_dates:
+            return min(manifest_dates)
+
+        return self.vars["start"].get()
+
     def _clear_set_history(self):
         """Deletes all locally downloaded datasets and schedules a fresh refresh on
         the next launch's splash screen. Useful when accumulated old sets slow
@@ -442,7 +454,7 @@ class DownloadWindow(ttk.Frame):
         ctx = {
             "set_key": self.vars["set"].get(),
             "event": self.vars["event"].get(),
-            "start": self.vars["start"].get(),
+            "start": self._resolve_start_date(self.vars["set"].get()),
             "end": self.vars["end"].get(),
             "time_period": constants.time_period_value(self.vars["period"].get()),
             "group": self.vars["group"].get(),

--- a/src/utils.py
+++ b/src/utils.py
@@ -21,6 +21,7 @@ from src.constants import (
     DATA_FIELD_MANA_COST,
     DATA_SECTION_IMAGES,
     FILTER_OPTION_ALL_DECKS,
+    time_period_label,
 )
 from src.logger import create_logger
 
@@ -110,6 +111,19 @@ def clear_set_history() -> int:
 
     invalidate_local_set_cache()
     return removed
+
+
+def read_local_manifest() -> dict:
+    """Reads the synced dataset manifest (Sets/local_manifest.json), returning
+    an empty dict if it's missing or unreadable."""
+    manifest_path = os.path.join(SETS_FOLDER, "local_manifest.json")
+    try:
+        if os.path.exists(manifest_path):
+            with open(manifest_path, "r", encoding="utf-8") as f:
+                return json.load(f)
+    except Exception:
+        pass
+    return {}
 
 
 def retrieve_local_set_list(codes=None, names=None):
@@ -357,12 +371,19 @@ def read_dataset_info(filename: str, codes=None, names=None):
             game_count = 0
 
         if is_custom:
-            try:
-                s = f"{start_date[5:7]}/{start_date[8:10]}"
-                e = f"{end_date[5:7]}/{end_date[8:10]}"
-                user_group = f"{user_group} ({s}-{e})"
-            except Exception:
-                user_group = f"{user_group} (Custom)"
+            # Preset-era downloads record meta.time_period; its label is the
+            # honest description of what was fetched. Older files fall back to
+            # the date-range suffix.
+            time_period = json_data["meta"].get("time_period")
+            if time_period:
+                user_group = f"{user_group} ({time_period_label(time_period)})"
+            else:
+                try:
+                    s = f"{start_date[5:7]}/{start_date[8:10]}"
+                    e = f"{end_date[5:7]}/{end_date[8:10]}"
+                    user_group = f"{user_group} ({s}-{e})"
+                except Exception:
+                    user_group = f"{user_group} (Custom)"
 
         return (
             set_name,

--- a/tests/test_download_panel.py
+++ b/tests/test_download_panel.py
@@ -66,6 +66,65 @@ class TestDownloadPanel:
         assert panel.vars["start"].get() == "2023-12-01"
         assert panel.vars["event"].get() == "PremierDraft"
 
+    def test_resolve_start_date_prefers_set_info(self, root, mock_sets_data, config):
+        """A set with a real start date uses it directly."""
+        panel = DownloadWindow(root, mock_sets_data, config, MagicMock())
+        assert panel._resolve_start_date("Outlaws") == "2024-04-16"
+
+    def test_resolve_start_date_manifest_fallback(self, root, config):
+        """A set stuck on the placeholder date (e.g. stale set-list cache) falls
+        back to the earliest start_date in the synced dataset manifest."""
+        from src.constants import START_DATE_DEFAULT
+
+        sets_data = MagicMock(
+            data={
+                "Marvel Super Heroes": SetInfo(
+                    arena=["ALL"],
+                    seventeenlands=["MSH"],
+                    formats=[],
+                    set_code="MARVEL",
+                    start_date=START_DATE_DEFAULT,
+                ),
+            }
+        )
+        panel = DownloadWindow(root, sets_data, config, MagicMock())
+
+        manifest = {
+            "datasets": {
+                "MSH_PremierDraft_All": {"start_date": "2026-06-23"},
+                "MSH_TradDraft_All": {"start_date": "2026-06-24"},
+                "TMT_PremierDraft_All": {"start_date": "2026-03-03"},
+            }
+        }
+        with patch(
+            "src.ui.windows.download.read_local_manifest", return_value=manifest
+        ):
+            assert panel._resolve_start_date("Marvel Super Heroes") == "2026-06-23"
+
+    def test_resolve_start_date_placeholder_without_manifest(self, root, config):
+        """No real set date and no manifest entry: keep the placeholder."""
+        from src.constants import START_DATE_DEFAULT
+
+        sets_data = MagicMock(
+            data={
+                "Marvel Super Heroes": SetInfo(
+                    arena=["ALL"],
+                    seventeenlands=["MSH"],
+                    formats=[],
+                    set_code="MARVEL",
+                    start_date=START_DATE_DEFAULT,
+                ),
+            }
+        )
+        panel = DownloadWindow(root, sets_data, config, MagicMock())
+
+        with patch(
+            "src.ui.windows.download.read_local_manifest", return_value={}
+        ):
+            assert (
+                panel._resolve_start_date("Marvel Super Heroes") == START_DATE_DEFAULT
+            )
+
     def test_threshold_sanitization(self, root, mock_sets_data, config):
         panel = DownloadWindow(root, mock_sets_data, config, MagicMock())
         panel.vars["threshold"].set("abc")

--- a/tests/test_file_extractor_extra.py
+++ b/tests/test_file_extractor_extra.py
@@ -125,12 +125,15 @@ def test_export_card_data(mock_open, mock_dump, mock_invalidate, mock_integrity)
     extractor.end_date = "2024-02-01"
     extractor.draft = "PremierDraft"
     extractor.user_group = "All"
+    extractor.time_period = "LATEST_EVENT"
     extractor.selected_sets = MagicMock()
     extractor.selected_sets.seventeenlands = ["OTJ"]
 
     filename = extractor.export_card_data()
 
-    assert "OTJ_PremierDraft_All_Custom-20240101-20240201_Data.json" in filename
+    # The stamp encodes the time_period preset so downloads of different
+    # presets on the same day don't overwrite each other.
+    assert "OTJ_PremierDraft_All_Custom-LatestEvent-20240201_Data.json" in filename
     mock_dump.assert_called_once()
     mock_invalidate.assert_called_once()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -90,6 +90,73 @@ def test_retrieve_local_set_list_skip_old(mock_integrity, mock_listdir, mock_exi
     assert file_list == MOCKED_DATASETS_LIST_VALID
 
 
+@patch("src.utils.os.path.exists")
+@patch("src.utils.os.listdir")
+@patch("src.utils.check_file_integrity")
+def test_retrieve_local_set_list_custom_preset_label(
+    mock_integrity, mock_listdir, mock_exists
+):
+    """Custom datasets downloaded with a time_period preset must display the
+    preset label (e.g. 'All (Latest Event)') instead of the placeholder date
+    range, which no longer describes what was fetched."""
+    import src.utils
+
+    src.utils._LOCAL_SET_CACHE = {"mtime": 0.0, "files": []}
+
+    mock_exists.return_value = True
+    mock_listdir.return_value = ["MSH_ContenderDraft_All_Custom-LatestEvent-20260708_Data.json"]
+    mock_integrity.return_value = (
+        Result.VALID,
+        {
+            "meta": {
+                "version": 3.0,
+                "start_date": "2019-01-01",
+                "end_date": "2026-07-08",
+                "time_period": "LATEST_EVENT",
+                "collection_date": "2026-07-08 19:36:27.000000",
+            }
+        },
+    )
+
+    file_list, error_list = retrieve_local_set_list(["MSH"])
+
+    assert not error_list
+    assert len(file_list) == 1
+    assert file_list[0][2] == "All (Latest Event)"
+
+
+@patch("src.utils.os.path.exists")
+@patch("src.utils.os.listdir")
+@patch("src.utils.check_file_integrity")
+def test_retrieve_local_set_list_custom_legacy_date_label(
+    mock_integrity, mock_listdir, mock_exists
+):
+    """Older custom datasets without meta.time_period keep the date-range label."""
+    import src.utils
+
+    src.utils._LOCAL_SET_CACHE = {"mtime": 0.0, "files": []}
+
+    mock_exists.return_value = True
+    mock_listdir.return_value = ["OTJ_PremierDraft_All_Custom-20240416-20240503_Data.json"]
+    mock_integrity.return_value = (
+        Result.VALID,
+        {
+            "meta": {
+                "version": 2,
+                "start_date": "2024-04-16",
+                "end_date": "2024-05-03",
+                "collection_date": "2024-05-03 10:15:45.788070",
+            }
+        },
+    )
+
+    file_list, error_list = retrieve_local_set_list(["OTJ"])
+
+    assert not error_list
+    assert len(file_list) == 1
+    assert file_list[0][2] == "All (04/16-05/03)"
+
+
 @pytest.mark.parametrize(
     "input_color, expected_output",
     [


### PR DESCRIPTION
Follow-up to #186. Manual dataset downloads still spoke the retired date-range language:

* unrealities: [UX/UI] Manual downloads are now labeled with their Time Period preset (e.g. "All (Latest Event)") in the Datasets table instead of a placeholder date range ("All (01/01-07/08)" with START 2019-01-01).
* unrealities: [Bug] Manual downloads record the set's true start date, falling back to the synced dataset manifest when the cached set list is stuck on the placeholder (the MSH case).
* unrealities: [Bug] Custom dataset filenames are stamped with the preset (`Custom-LatestEvent-<date>`), so downloading different presets on the same day no longer silently overwrites the previous file.

## Verification
- [x] Full test suite: 658 passed, 1 skipped (5 new tests)
- [x] Real-file check: the previously downloaded `MSH_ContenderDraft_All_Custom-20190101-20260708_Data.json` now renders as "All (Latest Event)" in the Datasets table; older date-range custom files keep their existing label

🤖 Generated with [Claude Code](https://claude.com/claude-code)
