### PR TITLE
Add The Hobbit (HOB) event schedule through September 29

### DIFF
--- a/server/calendar.json
+++ b/server/calendar.json
@@ -409,6 +409,185 @@
             ],
             "start_date": "2026-08-04",
             "end_date": "2026-08-09"
+        },
+        {
+            "set_code": "HOB",
+            "formats": [
+                "PremierDraft",
+                "TradDraft",
+                "PickTwoDraft"
+            ],
+            "start_date": "2026-08-11",
+            "end_date": "2026-09-29"
+        },
+        {
+            "set_code": "HOB",
+            "formats": [
+                "Sealed"
+            ],
+            "start_date": "2026-08-11",
+            "end_date": "2026-09-08"
+        },
+        {
+            "set_code": "HOB",
+            "formats": [
+                "TradSealed"
+            ],
+            "start_date": "2026-08-11",
+            "end_date": "2026-08-25"
+        },
+        {
+            "set_code": "HOB + LTR",
+            "formats": [
+                "Sealed"
+            ],
+            "start_date": "2026-08-28",
+            "end_date": "2026-09-03"
+        },
+        {
+            "set_code": "DSK",
+            "formats": [
+                "QuickDraft"
+            ],
+            "start_date": "2026-08-11",
+            "end_date": "2026-08-19"
+        },
+        {
+            "set_code": "HOB",
+            "formats": [
+                "QuickDraft"
+            ],
+            "start_date": "2026-08-20",
+            "end_date": "2026-08-30"
+        },
+        {
+            "set_code": "SOS",
+            "formats": [
+                "QuickDraft"
+            ],
+            "start_date": "2026-08-31",
+            "end_date": "2026-09-07"
+        },
+        {
+            "set_code": "LTR",
+            "formats": [
+                "PremierDraft"
+            ],
+            "start_date": "2026-08-25",
+            "end_date": "2026-09-07"
+        },
+        {
+            "set_code": "MH3",
+            "formats": [
+                "PremierDraft"
+            ],
+            "start_date": "2026-09-08",
+            "end_date": "2026-09-15"
+        },
+        {
+            "set_code": "DMU",
+            "formats": [
+                "PremierDraft"
+            ],
+            "start_date": "2026-09-16",
+            "end_date": "2026-09-21"
+        },
+        {
+            "set_code": "OTJ",
+            "formats": [
+                "PremierDraft"
+            ],
+            "start_date": "2026-09-22",
+            "end_date": "2026-09-28"
+        },
+        {
+            "set_code": "Mixed-Up",
+            "formats": [
+                "PremierDraft"
+            ],
+            "start_date": "2026-09-04",
+            "end_date": "2026-09-18"
+        },
+        {
+            "set_code": "Cube - Powered",
+            "formats": [
+                "PremierDraft",
+                "TradDraft"
+            ],
+            "start_date": "2026-09-08",
+            "end_date": "2026-09-28"
+        },
+        {
+            "set_code": "HOB",
+            "formats": [
+                "ContenderDraft"
+            ],
+            "start_date": "2026-08-24",
+            "end_date": "2026-09-29"
+        },
+        {
+            "set_code": "HOB",
+            "formats": [
+                "ArenaDirect"
+            ],
+            "start_date": "2026-08-14",
+            "end_date": "2026-08-23"
+        },
+        {
+            "set_code": "HOB",
+            "formats": [
+                "ArenaDirect"
+            ],
+            "start_date": "2026-08-28",
+            "end_date": "2026-09-06"
+        },
+        {
+            "set_code": "DFT",
+            "formats": [
+                "ArenaDirect"
+            ],
+            "start_date": "2026-09-15",
+            "end_date": "2026-09-20"
+        },
+        {
+            "set_code": "MOM",
+            "formats": [
+                "ArenaDirect"
+            ],
+            "start_date": "2026-09-25",
+            "end_date": "2026-09-27"
+        },
+        {
+            "set_code": "HOB",
+            "formats": [
+                "LimitedOpen"
+            ],
+            "start_date": "2026-09-11",
+            "end_date": "2026-09-13"
+        },
+        {
+            "set_code": "HOB",
+            "formats": [
+                "QualifierPlayIn"
+            ],
+            "start_date": "2026-09-12",
+            "end_date": "2026-09-12"
+        },
+        {
+            "set_code": "HOB",
+            "formats": [
+                "TradQualifierPlayIn"
+            ],
+            "start_date": "2026-09-18",
+            "end_date": "2026-09-18"
+        },
+        {
+            "set_code": "HOB",
+            "formats": [
+                "QualifierWeekend"
+            ],
+            "start_date": "2026-09-19",
+            "end_date": "2026-09-20"
         }
     ]
 }


### PR DESCRIPTION
## What changed

Adds 22 entries to `server/calendar.json` covering the Magic: The Gathering | The Hobbit release window (August 11 – September 29, 2026), picking up exactly where the Marvel Super Heroes schedule ended on August 10.

| Event | Dates |
|---|---|
| HOB Premier / Traditional / Pick-Two Draft | Aug 11 – Sep 29 |
| HOB Sealed | Aug 11 – Sep 8 |
| HOB Traditional Sealed | Aug 11 – Aug 25 |
| HOB + LTR Sealed | Aug 28 – Sep 3 |
| HOB Contender Draft | Aug 24 – Sep 29 |
| Quick Draft | DSK Aug 11–19, HOB Aug 20–30, SOS Aug 31 – Sep 7 |
| Flashback Premier Draft | LTR Aug 25 – Sep 7, MH3 Sep 8–15, DMU Sep 16–21, OTJ Sep 22–28 |
| Mixed-Up Premier Draft | Sep 4 – 18 |
| Cube - Powered | Sep 8 – 28 |
| Arena Direct | HOB Aug 14–23, HOB Aug 28 – Sep 6, DFT Sep 15–20, MOM Sep 25–27 |
| HOB Limited Open | Sep 11 – 13 |
| HOB Qualifiers | Play-In Sep 12, Trad Play-In Sep 18, Weekend Sep 19–20 |

## Why

The calendar previously ended on August 10, so nothing was scheduled for the new set. Since `server/calendar.json` also drives which datasets the ETL pulls from 17Lands (`server/main.py:82`), an empty calendar means no HOB data gets downloaded at all.

## Source

The [August 10 announcement](https://magic.wizards.com/en/news/mtg-arena/announcements-august-10-2026) contains no limited calendar itself — it links out to the [Hobbit event schedule](https://magic.wizards.com/en/news/mtg-arena/the-hobbit-event-schedule), which is where these dates come from. The set code `HOB` is confirmed via Scryfall and the `MTGHOB` card identifiers in the announcement.

## Reviewer notes

Three judgment calls worth a look:

- **Constructed events omitted.** Midweek Magic, both Metagame Challenges, Welcome Deck Duels, Yargle Day, and the **August qualifiers (Timeless format)** are all left out. Every existing entry in this file is set-scoped, and a Timeless qualifier has no meaningful `set_code`. Only the September qualifiers are included, since those are HOB Sealed. Easy to add August's if you'd rather have them.
- **`LimitedOpen` is a new format string.** It falls through to the `Default` slate color in `server/templates/calendar.js:12`, the same as the existing `ContenderDraft` / `ArenaDirect` / `QualifierPlayIn` entries. Worth a dedicated color if you want it to stand out.
- **Quick Draft is deliberately incomplete.** The schedule's prose describes a seven-week rotation continuing through The Lost Caverns of Ixalan and back to HOB, but the published table only gives dates through September 7. Rather than invent the remaining dates, this stops where WotC's data stops — a follow-up will be needed once they post them.

On the ETL side, entries 17Lands has no data for (`HOB + LTR`, `Mixed-Up`, `ArenaDirect`, qualifiers) log a warning and skip at `server/main.py:195`, matching how the existing MSH Arena Direct and qualifier entries already behave. No pipeline change was needed.

## Testing

- `server/calendar.json` parses as valid JSON; all 72 entries have `end_date >= start_date`.
- Rendered `calendar.html` against a local static server: August and September both draw every event bar with no error status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
