### PR TITLE
Fix startup crash on Tcl 9: guard the reference the call site uses

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ def _safe_setlocale(category, loc=None):
 locale.setlocale = _safe_setlocale
 
 import ttkbootstrap as ttk
+from ttkbootstrap import localization
 from ttkbootstrap.localization import msgs
 
 # Intercept TclErrors thrown by ttkbootstrap's localization engine on systems with outdated/missing msgcat Tcl packages.
@@ -35,7 +36,19 @@ def _safe_initialize_localities(*args, **kwargs):
         pass
 
 
+# Kept so tests can assert the guard is actually wrapping the real function.
+_safe_initialize_localities.__wrapped_original__ = _orig_initialize_localities
+
+
 msgs.initialize_localities = _safe_initialize_localities
+
+# ttkbootstrap/localization/__init__.py does `from .msgs import initialize_localities`,
+# which binds its own reference at import time, and Style.__init__ calls
+# `localization.initialize_localities()`. Patching only `msgs` therefore leaves the
+# call site pointing at the original function, so the guard above never fires and the
+# app still dies with `invalid command name "::msgcat::mcmset"` on distributions that
+# ship Tcl 9 (Fedora 42+, Nobara, Bazzite). Patch the package-level name too.
+localization.initialize_localities = _safe_initialize_localities
 
 import argparse
 import os

--- a/tests/test_localization_guard.py
+++ b/tests/test_localization_guard.py
@@ -1,0 +1,68 @@
+"""
+tests/test_localization_guard.py
+Regression tests for the ttkbootstrap msgcat guard installed by main.py.
+
+Background: on distributions shipping Tcl 9 (Fedora 42+, Nobara, Bazzite) the
+frozen Linux build dies at startup with:
+
+    _tkinter.TclError: invalid command name "::msgcat::mcmset"
+
+main.py already wraps `initialize_localities` to swallow that error, but the
+guard used to patch only `ttkbootstrap.localization.msgs.initialize_localities`.
+`ttkbootstrap/localization/__init__.py` does `from .msgs import
+initialize_localities`, binding its own reference at import time, and
+`Style.__init__` calls `localization.initialize_localities()` -- so the guard
+never covered the actual call site.
+"""
+
+import tkinter
+import pytest
+
+import main  # noqa: F401  (importing installs the guards)
+from ttkbootstrap import localization
+from ttkbootstrap.localization import msgs
+
+
+class TestLocalizationGuard:
+    def test_msgs_reference_is_patched(self):
+        """The original guard: the name inside the msgs module."""
+        assert msgs.initialize_localities.__name__ == "_safe_initialize_localities"
+
+    def test_package_reference_is_patched(self):
+        """
+        The call site actually used by ttkbootstrap.style.Style.__init__.
+        This is the assertion that fails without the fix.
+        """
+        assert (
+            localization.initialize_localities.__name__
+            == "_safe_initialize_localities"
+        )
+
+    def test_guard_swallows_msgcat_failure(self, monkeypatch):
+        """
+        Simulate a Tcl runtime whose msgcat lacks ::msgcat::mcmset and verify
+        the call site no longer propagates the error.
+        """
+
+        def boom(*args, **kwargs):
+            raise tkinter.TclError('invalid command name "::msgcat::mcmset"')
+
+        monkeypatch.setattr(localization.MessageCatalog, "set_many", boom)
+
+        # Must not raise.
+        localization.initialize_localities()
+
+    def test_unguarded_call_would_have_raised(self, monkeypatch):
+        """
+        Sanity check that the simulation above is faithful: the *original*
+        implementation does propagate the TclError.
+        """
+
+        def boom(*args, **kwargs):
+            raise tkinter.TclError('invalid command name "::msgcat::mcmset"')
+
+        monkeypatch.setattr(localization.MessageCatalog, "set_many", boom)
+
+        original = msgs.initialize_localities.__wrapped_original__
+        with pytest.raises(tkinter.TclError):
+            original()


### PR DESCRIPTION
## Problem

The frozen Linux build dies immediately on distributions shipping Tcl 9 (Fedora 42+, Nobara, Bazzite):

```
Fatal error during UI initialization: invalid command name "::msgcat::mcmset"
Traceback (most recent call last):
  File "main.py", line 312, in main
  File "main.py", line 275, in launch_ui
  File "ttkbootstrap/window.py", line 337, in __init__
  File "ttkbootstrap/style.py", line 611, in __init__
  File "ttkbootstrap/localization/msgs.py", line 60, in initialize_localities
_tkinter.TclError: invalid command name "::msgcat::mcmset"
```

The window that remains is an empty 200px black square, and the process keeps running in the background, so it looks like the app started when it did not.

## Cause

`main.py` already wraps `initialize_localities` to swallow exactly this error, and the comment names the very message above. But it patches `ttkbootstrap.localization.msgs.initialize_localities`, while `ttkbootstrap/localization/__init__.py` does

```python
from ttkbootstrap.localization.msgs import initialize_localities
```

which binds its own reference at import time, and `Style.__init__` calls `localization.initialize_localities()`.

The existing guard therefore never covered the actual call site.

## Fix

Patch the package-level name as well. Two lines. No behaviour change anywhere the app already started, since the wrapper only swallows an exception that would otherwise be fatal.

## Tests

`tests/test_localization_guard.py` asserts both references are wrapped, and simulates a Tcl runtime whose msgcat lacks `mcmset`. Without the fix, `test_package_reference_is_patched` and `test_guard_swallows_msgcat_failure` both fail with the production error; with it, all four pass.

Full suite on this branch: 681 passed, 1 skipped.

## Notes

The root cause is that the PyInstaller bundle ships Tcl/Tk 8.6 (`libtcl8.6.so`, `msgcat-1.6.1.tm`) while these distributions provide Tcl/Tk 9.0. Running from source on the same machine works, which is why this only shows up in the released binary. Fixing the bundled runtime would be the deeper change; this PR just makes the guard you already wrote do its job.